### PR TITLE
Refs #89.  Checkpointing progress on test.

### DIFF
--- a/pyrs/core/mantid_fit_peak.py
+++ b/pyrs/core/mantid_fit_peak.py
@@ -140,6 +140,7 @@ class MantidPeakFitEngine(peak_fit_engine.PeakFitEngine):
         checkdatatypes.check_string_variable('Background function name', background_function_name,
                                              ['Linear', 'Flat', 'Quadratic'])
         checkdatatypes.check_series('(To fit) sub runs range', sub_run_range, None, 2)
+        checkdatatypes.check_tuple('Peak range', peak_range, 2)
 
         self._fit_peaks_checks(sub_run_range, peak_function_name, background_function_name, peak_center, peak_range,
                                cal_center_d)

--- a/tests/unit/test_peak_fit_engine.py
+++ b/tests/unit/test_peak_fit_engine.py
@@ -121,7 +121,7 @@ def generate_hydra_workspace(peak_profile_type):
                                                 bin_edges=vec_x,
                                                 hist=vec_y)
 
-    return test_workspace, peak_center, peak_range
+    return test_workspace, peak_center, (peak_center - peak_range, peak_center + peak_center)
 
 
 def test_gaussian():


### PR DESCRIPTION
Error message:
```
pyrs/core/mantid_fit_peak.py:227: in fit_peaks
    FittedPeaksWorkspace=r_model_ws_name)
    ../../Mantid/Framework/PythonInterface/mantid/simpleapi.py:1136: in
    algorithm_wrapper
        _check_mandatory_args(name, algm, e, *args, **kwargs)
	_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
	_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
	_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

	algorithm = 'FitPeaks', _algm_object = <_api.AlgorithmProxy
	object at 0x7f264ed23aa0>, error = RuntimeError('Some invalid
	Properties found',), args = ()
	kwargs = {'BackgroundType': 'Linear', 'ConstrainPeakPositions':
	False, 'FindBackgroundSigma': 1, 'FitPeakWindowWorkspace':
	'fit_window_test', ...}, missing_arg_list = []
	props = ['InputWorkspace', 'PeakCentersWorkspace',
	'FitPeakWindowWorkspace', 'StartWorkspaceIndex',
	'StopWorkspaceIndex', 'PeakCenters', ...], p =
	'RawPeakParameters'
	prop = <_kernel.BoolPropertyWithValue object at 0x7f263f3937c0>,
	valid_str = ''

	    def _check_mandatory_args(algorithm, _algm_object, error,
	    *args, **kwargs):
	            """When a runtime error of the form 'Some invalid
		    Properties found'
		            is thrown call this function to return more
			    specific message to user in
			            the python output.
				            """
					            missing_arg_list =
						    []
						            # Returns
							    # all user
							    # defined
							    # properties
							            props
								    =
								    _algm_object.mandatoryProperties()
								            # Add
									    # given
									    # positional
									    # arguments
									    # to
									    # keyword
									    # arguments
									            for
										    (key,
										    arg)
										    in
										    zip(props[:len(args)],
										    args):
										                kwargs[key]
												=
												arg
												        for
													p
													in
													props:
													            prop
														    =
														    _algm_object.getProperty(p)
														                # Mandatory
																# properties
																# are
																# ones
																# with
																# invalid
																# defaults
																            if
																	    isinstance(prop.isValid,
																	    str):
																	                    valid_str
																			    =
																			    prop.isValid
																			                else:
																					                valid_str
																							=
																							prop.isValid()
																							            if
																								    len(valid_str)
																								    > 0
																								    > and
																								    > p
																								    > not
																								    > in
																								    > kwargs.keys():
																								                    missing_arg_list.append(p)
																										            if
																											    len(missing_arg_list)
																											    !=
																											    0:
																											                raise
																													RuntimeError("%s
																													argument(s)
																													not
																													supplied
																													to
																													%s"
																													%%
																													%(missing_arg_list,
																													%algorithm))
																													        # If
																														# the
																														# error
																														# was
																														# not
																														# caused
																														# by
																														# missing
																														# property
																														# the
																														# algorithm
																														# specific
																														# error
																														# should
																														# suffice
																														        else:
																															>           raise
																															>           RuntimeError(str(error))
																															E
																															RuntimeError:
																															Some
																															invalid
 Properties found
```