### PR TITLE
Move common parameters into constructor

### DIFF
--- a/pyrs/core/mantid_fit_peak.py
+++ b/pyrs/core/mantid_fit_peak.py
@@ -310,9 +310,8 @@ class MantidPeakFitEngine(peak_fit_engine.PeakFitEngine):
         fit_cost_array = peak_params_value_array['chi2']
 
         # Create PeakCollection instance
-        peak_object = PeakCollection(peak_tag)
-        peak_object.set_peak_fitting_values(peak_profile_name, background_type_name, sub_runs,
-                                            peak_params_value_array, peak_params_error_array, fit_cost_array)
+        peak_object = PeakCollection(peak_tag, peak_profile_name, background_type_name)
+        peak_object.set_peak_fitting_values(sub_runs, peak_params_value_array, peak_params_error_array, fit_cost_array)
 
         # Set to dictionary
         self._peak_collection_dict[peak_tag] = peak_object

--- a/pyrs/core/peak_collection.py
+++ b/pyrs/core/peak_collection.py
@@ -10,21 +10,25 @@ class PeakCollection(object):
     """
     Class for a collection of peaks
     """
-    def __init__(self, peak_tag):
+    def __init__(self, peak_tag, peak_profile, background_type):
         """Initialization
 
         Parameters
         ----------
         peak_tag : str
             tag for the peak such as 'Si111'
+        peak_profile : str
+            Peak profile
+        background_type : str
+            Background type
 
         """
         # Init variables from input
         self._tag = peak_tag
 
         # Init other parameters
-        self._peak_profile = None
-        self._background_type = None
+        self._peak_profile = peak_profile
+        self._background_type = background_type
 
         # sub run numbers: 1D array
         self._sub_run_array = None
@@ -34,8 +38,6 @@ class PeakCollection(object):
         self._params_error_array = None
         # fitting cost (chi2): numpy 1D array
         self._fit_cost_array = None
-
-        return
 
     @property
     def peak_tag(self):
@@ -89,16 +91,11 @@ class PeakCollection(object):
     def fitting_costs(self):
         return self._fit_cost_array
 
-    def set_peak_fitting_values(self, peak_profile, background_type, sub_runs, parameter_values,
-                                parameter_errors, fit_costs):
+    def set_peak_fitting_values(self, sub_runs, parameter_values, parameter_errors, fit_costs):
         """Set peak fitting values
 
         Parameters
         ----------
-        peak_profile : str
-            Peak profile
-        background_type : str
-            Background type
         sub_runs : numpy.array
             1D numpy array for sub run numbers
         parameter_values : numpy.ndarray
@@ -112,9 +109,6 @@ class PeakCollection(object):
         -------
 
         """
-        self._peak_profile = peak_profile
-        self._background_type = background_type
-
         self._sub_run_array = np.copy(sub_runs)
         self._params_value_array = np.copy(parameter_values)
         self._params_error_array = np.copy(parameter_errors)

--- a/tests/unit/test_hidra_project_file.py
+++ b/tests/unit/test_hidra_project_file.py
@@ -6,6 +6,7 @@ import os
 import numpy as np
 import datetime
 from pyrs.core import peak_profile_utility
+from pyrs.core.peak_collection import PeakCollection
 import pytest
 
 
@@ -166,9 +167,8 @@ def test_peak_fitting_result_io():
     test_params_array[HidraConstants.PEAK_FIT_CHI2] = chi2_array
 
     # Add test data to output
-    from pyrs.core.peak_collection import PeakCollection
-    peaks = PeakCollection('test fake')
-    peaks.set_peak_fitting_values('PseudoVoigt', 'Linear', np.array([1, 2, 3]), test_params_array, test_error_array,
+    peaks = PeakCollection('test fake', 'PseudoVoigt', 'Linear')
+    peaks.set_peak_fitting_values(np.array([1, 2, 3]), test_params_array, test_error_array,
                                   chi2_array)
 
     test_project_file.write_peak_fit_result(peaks)


### PR DESCRIPTION
Since peak objects shouldn't hold multiple profile functions, move that into the constructor.