### PR TITLE
Specify default mixing parameter only

### DIFF
--- a/pyrs/peaks/mantid_fit_peak.py
+++ b/pyrs/peaks/mantid_fit_peak.py
@@ -34,11 +34,8 @@ class MantidPeakFitEngine(PeakFitEngine):
         # add in extra parameters for starting values
         kwargs = {}
         if self._peak_function == PeakShape.PSEUDOVOIGT:
-            # max_intensity = PseudoVoigt.cal_intensity(max_estimated_height, hidra_fwhm, default_mixing)
-            intensity = self._mtd_wksp.extractY().max() - self._mtd_wksp.extractY().mean()  # TODO improve this
-
-            kwargs['PeakParameterNames'] = 'Mixing, Intensity'  # FWHM also available
-            kwargs['PeakParameterValues'] = '{}, {}'.format(0.6, intensity)  # mixing agreed upon default
+            kwargs['PeakParameterNames'] = 'Mixing'  # FWHM and Intensity also available
+            kwargs['PeakParameterValues'] = '0.6'  # mixing agreed upon default
 
         # Fit peak by Mantid.FitPeaks
         fit_return = FitPeaks(InputWorkspace=self._mtd_wksp,

--- a/tests/unit/test_peak_fit_engine.py
+++ b/tests/unit/test_peak_fit_engine.py
@@ -1,11 +1,15 @@
 from __future__ import (absolute_import, division, print_function)  # python3 compatibility
+from matplotlib import pyplot as plt
 import numpy as np
+import os
 from pyrs.peaks import FitEngineFactory as PeakFitEngineFactory
 from pyrs.core.workspaces import HidraWorkspace
 from pyrs.core.peak_profile_utility import pseudo_voigt, PeakShape, BackgroundFunction
 from pyrs.core.peak_profile_utility import Gaussian, PseudoVoigt
 import pytest
-from matplotlib import pyplot as plt
+
+# set to True when running on build servers
+ON_TRAVIS = (os.environ.get('TRAVIS', 'false').upper() == 'TRUE')
 
 
 def generate_test_gaussian(vec_x, peak_center_list, peak_range_list, peak_height_list):
@@ -573,6 +577,8 @@ def test_3_gaussian_3_subruns(target_values):
                                       ' not {}'.format(fit_cost2_lp[2])
 
 
+# pseudo-Voigt peak fitting only works on mantid versions with https://github.com/mantidproject/mantid/pull/27809
+@pytest.mark.skipif(ON_TRAVIS, reason='Need mantid version > 4.2.20200128')
 @pytest.mark.parametrize("setup_1_subrun", [{'peak_profile_type': 'PseudoVoigt', 'min_x': 75., 'max_x': 85.,
                                              'num_x': 500, 'peak_center': [80.], 'peak_range': [10. * 0.25],
                                              'peak_intensities':[100.]}], indirect=True)

--- a/tests/unit/test_peak_fit_engine.py
+++ b/tests/unit/test_peak_fit_engine.py
@@ -631,7 +631,8 @@ def test_1_pv_1_subrun(setup_1_subrun, fit_domain):
 
     if fit_costs[0] > 1.0:
         # Plot
-        model_x, model_y = fit_engine.calculate_fitted_peaks(1, None)
+        model_x = fit_result.fitted.readX(0)
+        model_y = fit_result.fitted.readY(0)
         data_x, data_y = setup_1_subrun['workspace'].get_reduced_diffraction_data(1, None)
         assert data_x.shape == model_x.shape
         assert data_y.shape == model_y.shape


### PR DESCRIPTION
This requires [mantid PR27809](https://github.com/mantidproject/mantid/pull/27809) before the pseudo-Voigt will actually work. However, this change won't break the currently working Gaussian peak fitting so it is safe to merge.

Fixes #293 