### PR TITLE
Allow for not having selected row

### DIFF
--- a/pyrs/interface/peak_fitting/event_handler.py
+++ b/pyrs/interface/peak_fitting/event_handler.py
@@ -273,6 +273,8 @@ class EventHandler:
     def fit_table_selection_changed(self):
         '''as soon as a row is selected, switch to the slider view and go to right sub_run'''
         row_selected = GuiUtilities.get_row_selected(table_ui=self.parent.ui.tableView_fitSummary)
+        if row_selected is None:
+            return
         self.parent.ui.radioButton_individualSubRuns.setChecked(True)
         self.parent.check_subRunsDisplayMode()
         self.parent.ui.horizontalScrollBar_SubRuns.setValue(row_selected+1)

--- a/pyrs/interface/peak_fitting/gui_utilities.py
+++ b/pyrs/interface/peak_fitting/gui_utilities.py
@@ -290,8 +290,11 @@ class GuiUtilities:
 
     @staticmethod
     def get_row_selected(table_ui=None):
-        selection = table_ui.selectedRanges()[0]
-        return selection.topRow()
+        selection = table_ui.selectedRanges()
+        if len(selection) > 0:
+            return selection[0].topRow()
+        else:
+            return None
 
     @staticmethod
     def make_visible_ui(list_ui=[], visible=True):


### PR DESCRIPTION
In the fit table, an exception is created after the data is fitted, before the the table is viewed.