### PR TITLE
Point to error array instead of value array

### DIFF
--- a/pyrs/core/peak_profile_utility.py
+++ b/pyrs/core/peak_profile_utility.py
@@ -391,11 +391,11 @@ class PseudoVoigt(PeakParametersConverter):
         # Set
         eff_error_array['Center'] = param_error_array['PeakCentre']  # center
         eff_error_array['Height'] = heights_error[:]  # height
-        eff_error_array['FWHM'] = param_value_array['FWHM']  # FWHM
-        eff_error_array['Mixing'] = param_value_array['Mixing']  # no mixing for Gaussian
-        eff_error_array['A0'] = param_value_array['A0']  # A0
-        eff_error_array['A1'] = param_value_array['A1']  # A1
-        eff_error_array['Intensity'] = param_value_array['Intensity']  # intensity
+        eff_error_array['FWHM'] = param_error_array['FWHM']  # FWHM
+        eff_error_array['Mixing'] = param_error_array['Mixing']  # no mixing for Gaussian
+        eff_error_array['A0'] = param_error_array['A0']  # A0
+        eff_error_array['A1'] = param_error_array['A1']  # A1
+        eff_error_array['Intensity'] = param_error_array['Intensity']  # intensity
 
         return eff_value_array, eff_error_array
 

--- a/tests/unit/test_peak_collection.py
+++ b/tests/unit/test_peak_collection.py
@@ -151,8 +151,8 @@ def test_peak_collection_PseudoVoigt():
                                    dtype=get_parameter_dtype(effective=True)))
     # with wavelength
     check_peak_collection('PseudoVoigt', NUM_SUBRUN,
-                          np.array([(0.0, 0.0, 4.0, 0.0, 0.0, 0.0, 1.0),
-                                    (0.0, 0.0, 5.0, 1.0, 0.0, 0.0, 2.0)],
+                          np.array([(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+                                    (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)],
                                    dtype=get_parameter_dtype(effective=True)),
                           wavelength=3.15, d_reference=2.5, target_d_spacing_center=[1.57, 1.73],
                           target_d_spacing_center_error=[0.0, 0.0], target_strain=[-0.378, -0.308],

--- a/tests/unit/test_peak_collection.py
+++ b/tests/unit/test_peak_collection.py
@@ -146,8 +146,8 @@ def test_peak_collection_PseudoVoigt():
     NUM_SUBRUN = 2
     # without wavelength
     check_peak_collection('PseudoVoigt', NUM_SUBRUN,
-                          np.array([(0.0, 0.0, 4.0, 0.0, 0.0, 0.0, 1.0),
-                                    (0.0, 0.0, 5.0, 1.0, 0.0, 0.0, 2.0)],
+                          np.array([(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+                                    (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)],
                                    dtype=get_parameter_dtype(effective=True)))
     # with wavelength
     check_peak_collection('PseudoVoigt', NUM_SUBRUN,


### PR DESCRIPTION
@peterfpeterson @JeanBilheux pointed out a copy/paste error where error arrays contained values. This corrects those oversights.