### PR TITLE
Move requirements into standard text files for re-use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 
 script:
     # TEST: Create test environment and test build
-  - conda create -q -n PyRS_test python=$CONDA flake8 pytest pytest-qt mantid-workbench=4.2 mypy uncertainties pytest-cov codecov scipy>=1.18
+  - conda create -q -n PyRS_test python=$CONDA mantid-workbench>=4.2 --file requirements.txt --file requirements_dev.txt
   - conda info --envs
   - conda activate PyRS_test
   - python --version

--- a/README.rst
+++ b/README.rst
@@ -14,26 +14,29 @@ If you've never used PyRS before, you can get started quickly by doing the follo
 2. Create a new Conda environment with additional dependencies:
 
 .. code-block::
-   
+
    $ conda create -n pyrs -c mantid -c mantid/label/nightly mantid-workbench -c conda-forge
 
 3. Activate the conda environment
 
 .. code-block::
-   
+
    $ conda activate pyrs
 
 4. From the PyRS directory, run the setup script in developer mode
 
 .. code-block::
-   
+
    $ python setup.py develop
 
 5. From the PyRS directory, start the user interface
 
 .. code-block::
-   
+
    $ python scripts/pyrsplot
+
+For those setting up in a virtual environment, the dependencies are listed in ``requirements.txt`` and ``requirements_dev.txt``.
+They can be supplide to ``conda create`` using the `--file`` argument, or to ``pip install`` using the ``-R`` argument.
 
 -----------------------
 Data reduction workflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+uncertainties
+scipy>=0.18

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,11 @@
+# INSTALL THE requirements.txt AS WELL
+
+# testing
+codecov
+pytest
+pytest-cov
+pytest-qt
+
+# linting and static analysis
+flake8
+mypy

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,21 @@ CLASSIFIERS = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-INSTALL_REQUIRES = []
 
 ###################################################################
 
-HERE = os.path.abspath(os.path.dirname(__file__))
+THIS_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+def read_requirements_from_file(filepath):
+    '''Read a list of requirements from the given file and split into a
+    list of strings. It is assumed that the file is a flat
+    list with one requirement per line.
+    :param filepath: Path to the file to read
+    :return: A list of strings containing the requirements
+    '''
+    with open(filepath, 'rU') as req_file:
+        return req_file.readlines()
 
 
 def read(*parts):
@@ -37,7 +47,7 @@ def read(*parts):
     Build an absolute path from *parts* and and return the contents of the
     resulting file.  Assume UTF-8 encoding.
     """
-    with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
+    with codecs.open(os.path.join(THIS_DIR, *parts), "rb", "utf-8") as f:
         return f.read()
 
 
@@ -58,6 +68,10 @@ def find_meta(meta):
     if meta_match:
         return meta_match.group(1)
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+
+
+install_requires = read_requirements_from_file(os.path.join(THIS_DIR, 'requirements.txt'))
+test_requires = read_requirements_from_file(os.path.join(THIS_DIR, 'requirements_dev.txt'))
 
 
 if __name__ == "__main__":
@@ -84,11 +98,10 @@ if __name__ == "__main__":
         packages=find_packages(exclude=['tests', 'tests.*']),
         zip_safe=False,
         classifiers=CLASSIFIERS,
-        install_requires=INSTALL_REQUIRES,
-        # from ours
+        install_requires=install_requires,
+        tests_require=test_requires,
         package_dir={},
         package_data={'': ['*.ui']},
         scripts=scripts,
         setup_requires=['pytest-runner'],
-        # tests_require=setup_args['install_requires'] + setup_args['tests_require'],
     )


### PR DESCRIPTION
This should reduce the number of places to update the list of requirements for the package. `mantid-workbench` is supplied separately since developer builds will often use mantid built locally rather than the `mantid-workbench` package.