### PR TITLE
Create Splitter without end time

### DIFF
--- a/scripts/reduce_manual_HB2B.py
+++ b/scripts/reduce_manual_HB2B.py
@@ -49,7 +49,7 @@ def _create_powder_patterns(hidra_workspace, instrument, calibration, mask, subr
                             append_mode):
     logger.notice('Adding powder patterns to Hidra Workspace{}'.format(hidra_workspace))
 
-    reducer = ReductionApp(bool(options.engine == 'mantid'))
+    reducer = ReductionApp()
     # reducer.load_project_file(projectfile)
     # load HidraWorkspace
     reducer.load_hidra_workspace(hidra_workspace)

--- a/tests/unit/test_splitter.py
+++ b/tests/unit/test_splitter.py
@@ -1,0 +1,74 @@
+from mantid.kernel import Int32TimeSeriesProperty as IntLog
+import numpy as np
+from pyrs.core.nexus_conversion import Splitter
+import pytest
+
+
+def test_empty_constructor():
+    # pass in empty dictionary
+    try:
+        _ = Splitter(dict())
+        assert False, 'Should not have created a Splitter'
+    except RuntimeError:
+        pass
+
+    try:
+        logs = {'scan_index': IntLog('scan_index')}
+        _ = Splitter(logs)
+        assert False, 'Should not have created a Splitter'
+    except RuntimeError:
+        pass
+
+
+def test_nominal():
+    # single scan index
+    scan_index = IntLog('scan_index')
+    scan_index.addValue('1999-03-31T12:00Z', 0)
+    scan_index.addValue('1999-03-31T12:01Z', 1)
+    scan_index.addValue('1999-03-31T12:02Z', 0)
+
+    splitter = Splitter({'scan_index': scan_index})
+
+    assert splitter.size == 1
+    np.testing.assert_equal(splitter.durations, [60])
+    np.testing.assert_equal(splitter.subruns, [1])
+
+    # add another scan index and create a new splitter
+    scan_index.addValue('1999-03-31T12:03Z', 2)
+    scan_index.addValue('1999-03-31T12:04Z', 0)
+
+    splitter = Splitter({'scan_index': scan_index})
+
+    assert splitter.size == 2
+    np.testing.assert_equal(splitter.durations, [60, 60])
+    np.testing.assert_equal(splitter.subruns, [1, 2])
+
+
+def test_no_end():
+    # when end isn't defined one day into the future is used
+    ONE_DAY = 24*60*60
+
+    # single scan index
+    scan_index = IntLog('scan_index')
+    scan_index.addValue('1999-03-31T12:00Z', 0)
+    scan_index.addValue('1999-03-31T12:01Z', 1)
+
+    splitter = Splitter({'scan_index': scan_index})
+
+    assert splitter.size == 1
+    np.testing.assert_equal(splitter.durations, [ONE_DAY])
+    np.testing.assert_equal(splitter.subruns, [1])
+
+    # add another scan index and create a new splitter
+    scan_index.addValue('1999-03-31T12:02Z', 0)
+    scan_index.addValue('1999-03-31T12:03Z', 2)
+
+    splitter = Splitter({'scan_index': scan_index})
+
+    assert splitter.size == 2
+    np.testing.assert_equal(splitter.durations, [60, ONE_DAY])
+    np.testing.assert_equal(splitter.subruns, [1, 2])
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
The issue came from runs where the run did not end with `scan_index=0`. This solution is to add an ending time 1 day into the future.

Fixes #471