### PR TITLE
Set the wavelength when reading PeakCollection from file

### DIFF
--- a/pyrs/projectfile/file_object.py
+++ b/pyrs/projectfile/file_object.py
@@ -641,7 +641,7 @@ class HidraProjectFile:
         if param_values.shape != error_values.shape:
             raise RuntimeError('Parameters[{}] and Errors[{}] have different shape'.format(param_values.shape,
                                                                                            error_values.shape))
-        peak_collection = PeakCollection(peak_tag, profile, background)
+        peak_collection = PeakCollection(peak_tag, profile, background, self.read_wavelengths())
         peak_collection.set_peak_fitting_values(subruns=sub_run_array, parameter_values=param_values,
                                                 parameter_errors=error_values, fit_costs=chi2_array)
 

--- a/tests/unit/test_hidra_project_file.py
+++ b/tests/unit/test_hidra_project_file.py
@@ -174,6 +174,7 @@ def test_peak_fitting_result_io():
 
     # Generate a HiDRA project file
     test_project_file = HidraProjectFile(test_file_name, HidraProjectFileMode.OVERWRITE)
+    test_project_file.write_wavelength(1.54)
 
     # Create a ND array for output parameters
     param_names = PeakShape.PSEUDOVOIGT.native_parameters + BackgroundFunction.LINEAR.native_parameters
@@ -232,6 +233,9 @@ def test_peak_fitting_result_io():
     # parameter values
     # assert np.allclose(peak_info[4], test_error_array, 1E-12)
     assert_allclose_structured_numpy_arrays(test_error_array, peak_errors)
+
+    dspacing, _ = peak_info.get_dspacing_center()
+    np.testing.assert_allclose(dspacing, [46.441864, 30.429281, 18.012734])
 
     # Clean
     os.remove(test_file_name)


### PR DESCRIPTION
Before this was set on reading the peaks the wavelength was just NaN and therefore d-spacing and strain were also NaN