### PR TITLE
StrainField from project file

### DIFF
--- a/pyrs/projectfile/file_object.py
+++ b/pyrs/projectfile/file_object.py
@@ -608,7 +608,7 @@ class HidraProjectFile:
         # Get main group
         peak_main_group = self._project_h5[HidraConstants.PEAKS]
 
-        return peak_main_group.keys()
+        return list(peak_main_group.keys())
 
     def read_peak_parameters(self, peak_tag):
         """Get the parameters related to a peak

--- a/pyrs/utilities/file_util.py
+++ b/pyrs/utilities/file_util.py
@@ -4,7 +4,9 @@ from mantid import ConfigService
 from mantid.api import FileFinder
 from mantid.simpleapi import mtd, GetIPTS, SaveNexusProcessed
 import os
+from pathlib import Path
 from subprocess import check_output
+from typing import Union
 
 __all__ = ['get_ipts_dir', 'get_default_output_dir', 'get_ipts_dir', 'get_input_project_file', 'get_nexus_file']
 
@@ -32,6 +34,23 @@ def save_mantid_nexus(workspace_name, file_name, title=''):
         raise RuntimeError('Workspace {0} does not exist in Analysis data service. Available '
                            'workspaces are {1}.'
                            ''.format(workspace_name, mtd.getObjectNames()))
+
+
+def to_filepath(filename: Union[str, Path], check_exists: bool = True) -> Path:
+    '''Asserts that a file exists and is a file.
+    Raises an exception if anything is wrongither assumption is incorrect'''
+    if not filename:  # empty value
+        raise ValueError('Encountered empty filename')
+
+    filepath = Path(filename)
+
+    if check_exists:
+        if not filepath.exists():
+            raise IOError('File "{}" not found'.format(filename))
+        if not filepath.is_file():
+            raise IOError('Path "{}" is not a file'.format(filename))
+
+    return filepath
 
 
 def get_temp_directory():

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -178,13 +178,28 @@ def test_create_strain_field():
     workspace.set_sample_log('vz', subruns, np.arange(21, 29, dtype=int))
 
     # call the function
-    strain = StrainField(workspace, peak_collection)
+    strain = StrainField(hidraworkspace=workspace, peak_collection=peak_collection)
 
     # test the result
     assert strain
     assert len(strain) == subruns.size
     np.testing.assert_almost_equal(strain.values, 0.)
     np.testing.assert_equal(strain.errors, np.zeros(subruns.size, dtype=float))
+
+
+def test_create_strain_field_from_file_no_peaks():
+    # this project file doesn't have peaks in it
+    filename = 'tests/data/HB2B_1060_first3_subruns.h5'
+    try:
+        _ = StrainField(filename)
+        assert False, 'Should not be able to read ' + filename
+    except IOError:
+        pass  # this is what should happen
+
+
+def test_create_strain_field_from_file_one_peak():
+    filename = 'tests/data/HB2B_1320.h5'
+    assert StrainField(filename)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds code for creating a `StrainField` directly from a project file. It does not currently support multiple peaks in a single project file.

Refs #427 
