### PR TITLE
Hidra Projct File now supports overwritting peak data

### DIFF
--- a/pyrs/projectfile/file_object.py
+++ b/pyrs/projectfile/file_object.py
@@ -707,24 +707,24 @@ class HidraProjectFile:
         self.set_attributes(single_peak_entry, HidraConstants.PEAK_PROFILE, peak_profile)
         self.set_attributes(single_peak_entry, HidraConstants.BACKGROUND_TYPE, background_type)
 
-        #Create or replace each dataset as appropriate
-        if(not HidraConstants.SUB_RUNS in single_peak_entry):
+        # Create or replace each dataset as appropriate
+        if(HidraConstants.SUB_RUNS not in single_peak_entry):
             single_peak_entry.create_dataset(HidraConstants.SUB_RUNS, data=fitted_peaks.sub_runs)
         else:
             single_peak_entry[HidraConstants.SUB_RUNS][...] = fitted_peaks.sub_runs
-            
-        if(not HidraConstants.PEAK_FIT_CHI2 in single_peak_entry):
+
+        if(HidraConstants.PEAK_FIT_CHI2 not in single_peak_entry):
             single_peak_entry.create_dataset(HidraConstants.PEAK_FIT_CHI2, data=fitted_peaks.fitting_costs)
         else:
             single_peak_entry[HidraConstants.PEAK_FIT_CHI2][...] = fitted_peaks.fitting_costs
-            
+
         peak_values, peak_errors = fitted_peaks.get_native_params()
-        if(not HidraConstants.PEAK_PARAMS in single_peak_entry):
+        if(HidraConstants.PEAK_PARAMS not in single_peak_entry):
             single_peak_entry.create_dataset(HidraConstants.PEAK_PARAMS, data=peak_values)
         else:
             single_peak_entry[HidraConstants.PEAK_PARAMS][...] = peak_values
-            
-        if(not HidraConstants.PEAK_PARAMS_ERROR in single_peak_entry):
+
+        if(HidraConstants.PEAK_PARAMS_ERROR not in single_peak_entry):
             single_peak_entry.create_dataset(HidraConstants.PEAK_PARAMS_ERROR, data=peak_errors)
         else:
             single_peak_entry[HidraConstants.PEAK_PARAMS_ERROR][...] = peak_errors
@@ -733,12 +733,12 @@ class HidraProjectFile:
         ref_d_array, ref_d_errors = fitted_peaks.get_d_reference()
         if isinstance(ref_d_array, numpy.ndarray):
             # if reference peak position in D is set
-            if(not HidraConstants.D_REFERENCE in single_peak_entry):
+            if(HidraConstants.D_REFERENCE not in single_peak_entry):
                 single_peak_entry.create_dataset(HidraConstants.D_REFERENCE, data=ref_d_array)
             else:
                 single_peak_entry[HidraConstants.D_REFERENCE][...] = ref_d_array
 
-            if(not HidraConstants.D_REFERENCE_ERROR in single_peak_entry):
+            if(HidraConstants.D_REFERENCE_ERROR not in single_peak_entry):
                 single_peak_entry.create_dataset(HidraConstants.D_REFERENCE_ERROR, data=ref_d_errors)
             else:
                 single_peak_entry[HidraConstants.D_REFERENCE_ERROR][...] = ref_d_errors

--- a/pyrs/projectfile/file_object.py
+++ b/pyrs/projectfile/file_object.py
@@ -707,18 +707,41 @@ class HidraProjectFile:
         self.set_attributes(single_peak_entry, HidraConstants.PEAK_PROFILE, peak_profile)
         self.set_attributes(single_peak_entry, HidraConstants.BACKGROUND_TYPE, background_type)
 
-        single_peak_entry.create_dataset(HidraConstants.SUB_RUNS, data=fitted_peaks.sub_runs)
-        single_peak_entry.create_dataset(HidraConstants.PEAK_FIT_CHI2, data=fitted_peaks.fitting_costs)
+        #Create or replace each dataset as appropriate
+        if(not HidraConstants.SUB_RUNS in single_peak_entry):
+            single_peak_entry.create_dataset(HidraConstants.SUB_RUNS, data=fitted_peaks.sub_runs)
+        else:
+            single_peak_entry[HidraConstants.SUB_RUNS][...] = fitted_peaks.sub_runs
+            
+        if(not HidraConstants.PEAK_FIT_CHI2 in single_peak_entry):
+            single_peak_entry.create_dataset(HidraConstants.PEAK_FIT_CHI2, data=fitted_peaks.fitting_costs)
+        else:
+            single_peak_entry[HidraConstants.PEAK_FIT_CHI2][...] = fitted_peaks.fitting_costs
+            
         peak_values, peak_errors = fitted_peaks.get_native_params()
-        single_peak_entry.create_dataset(HidraConstants.PEAK_PARAMS, data=peak_values)
-        single_peak_entry.create_dataset(HidraConstants.PEAK_PARAMS_ERROR, data=peak_errors)
+        if(not HidraConstants.PEAK_PARAMS in single_peak_entry):
+            single_peak_entry.create_dataset(HidraConstants.PEAK_PARAMS, data=peak_values)
+        else:
+            single_peak_entry[HidraConstants.PEAK_PARAMS][...] = peak_values
+            
+        if(not HidraConstants.PEAK_PARAMS_ERROR in single_peak_entry):
+            single_peak_entry.create_dataset(HidraConstants.PEAK_PARAMS_ERROR, data=peak_errors)
+        else:
+            single_peak_entry[HidraConstants.PEAK_PARAMS_ERROR][...] = peak_errors
 
         # Reference peak center in dSpacing: (strain)
         ref_d_array, ref_d_errors = fitted_peaks.get_d_reference()
         if isinstance(ref_d_array, numpy.ndarray):
             # if reference peak position in D is set
-            single_peak_entry.create_dataset(HidraConstants.D_REFERENCE, data=ref_d_array)
-            single_peak_entry.create_dataset(HidraConstants.D_REFERENCE_ERROR, data=ref_d_errors)
+            if(not HidraConstants.D_REFERENCE in single_peak_entry):
+                single_peak_entry.create_dataset(HidraConstants.D_REFERENCE, data=ref_d_array)
+            else:
+                single_peak_entry[HidraConstants.D_REFERENCE][...] = ref_d_array
+
+            if(not HidraConstants.D_REFERENCE_ERROR in single_peak_entry):
+                single_peak_entry.create_dataset(HidraConstants.D_REFERENCE_ERROR, data=ref_d_errors)
+            else:
+                single_peak_entry[HidraConstants.D_REFERENCE_ERROR][...] = ref_d_errors
         else:
             raise RuntimeError('Unexpected type for reference d-values')
 

--- a/tests/unit/test_hidra_project_file.py
+++ b/tests/unit/test_hidra_project_file.py
@@ -192,7 +192,14 @@ def test_peak_fitting_result_io():
     # END-FOR
     chi2_array = np.array([0.323, 0.423, 0.523])
 
-    # Add test data to output
+    # Add some original test data
+    peaks = PeakCollection('test fake', PeakShape.PSEUDOVOIGT, BackgroundFunction.LINEAR)
+    peaks.set_peak_fitting_values(np.array([11, 21, 31]), np.ones(3, dtype=data_type), np.ones(3, dtype=data_type),
+                                  np.array([1.323, 1.423, 1.523]))
+
+    test_project_file.write_peak_parameters(peaks)
+
+    # Replace the peaks data with the real data that will be tested for
     peaks = PeakCollection('test fake', PeakShape.PSEUDOVOIGT, BackgroundFunction.LINEAR)
     peaks.set_peak_fitting_values(np.array([1, 2, 3]), test_params_array, test_error_array,
                                   chi2_array)


### PR DESCRIPTION
Fixed a bug which stopped the Hidra Project File from writing peak data
if peak data already existed.

Fixes #512 

Signed-off-by: Robert Smith <smithrw@ornl.gov>