### PR TITLE
Remove clone methods from classes in module dataobjects.field

### DIFF
--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -1,4 +1,3 @@
-import copy
 from enum import Enum
 from enum import unique as unique_enum
 import numpy as np

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -89,10 +89,6 @@ class ScalarFieldSample:
     def z(self) -> List[float]:
         return self._point_list.vz
 
-    def clone(self):
-        r"""Obtain an identical copy of this field"""
-        return copy.deepcopy(self)
-
     @property
     def isfinite(self) -> 'ScalarFieldSample':
         r"""
@@ -441,14 +437,6 @@ class StrainField(ScalarFieldSample):
 
         # TODO the fixed name shouldn't bee needed with inheritence
         return super().__init__('strain', strain, strain_error, x, y, z)
-
-    def clone(self):
-        r"""
-        Obtain an identical copy of this strain field.
-
-        All attributes are replicated, except `_peak_collection`
-        """
-        return copy.deepcopy(self, memo={id(self._peak_collection): self._peak_collection})
 
     @property
     def get_peak_collection(self):

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -260,19 +260,6 @@ class TestScalarFieldSample:
         field = ScalarFieldSample(*TestScalarFieldSample.sample1)
         np.testing.assert_equal(field.z, TestScalarFieldSample.sample1.z)
 
-    def test_clone(self):
-        field = ScalarFieldSample(*TestScalarFieldSample.sample1)
-        clone = field.clone()
-        assert id(clone) != id(field)
-        for attribute in ('name', 'values', 'errors', 'x', 'y', 'z'):
-            clone_attribute = getattr(clone, attribute)
-            field_attribute = getattr(field, attribute)
-            if isinstance(field_attribute, str) is True:
-                assert clone_attribute == field_attribute
-            else:
-                assert id(clone_attribute) != id(field_attribute)  # different addresses in memory
-                assert np.allclose(clone_attribute, field_attribute)  # compare the values
-
     def test_isfinite(self):
         field = ScalarFieldSample(*TestScalarFieldSample.sample4).isfinite
         for attribute in ('values', 'errors', 'x', 'y', 'z'):
@@ -516,22 +503,6 @@ def strain_field_samples():
     return sample_fields
 
 
-class TestStrainField:
-
-    def test_clone(self, strain_field_samples):
-        field = strain_field_samples['strain with two points per direction']
-        clone = field.clone()
-        assert id(clone) != id(field)
-        for attribute in ('_peak_collection', 'name', 'values', 'errors', 'x', 'y', 'z'):
-            clone_attribute = getattr(clone, attribute)
-            field_attribute = getattr(field, attribute)
-            if isinstance(field_attribute, (PeakCollection, str)) is True:
-                assert id(clone_attribute) == id(field_attribute)
-            else:
-                assert id(clone_attribute) != id(field_attribute)  # different addresses in memory
-                assert np.allclose(clone_attribute, field_attribute)  # compare the values
-
-
 def test_create_strain_field_from_file_no_peaks():
     # this project file doesn't have peaks in it
     filename = 'tests/data/HB2B_1060_first3_subruns.h5'
@@ -668,26 +639,6 @@ class TestStressField:
         field = StressField(*strains_for_stress_field_1, 1.0, poisson_ratio)
         assert field.poisson_ratio == pytest.approx(poisson_ratio)
 
-    def test_clone(self, stress_samples):
-        field = stress_samples['stress diagonal']
-        clone = field.clone()
-        assert clone.__class__ == field.__class__
-        assert id(clone) != id(field)
-        for attribute in ('name', 'values', 'errors', 'x', 'y', 'z',
-                          'direction', 'stress_type', '_youngs_modulus', '_poisson_ratio'):
-            clone_attribute = getattr(clone, attribute)
-            field_attribute = getattr(field, attribute)
-            if isinstance(field_attribute, (str, enum.Enum)) is True:
-                assert clone_attribute == field_attribute
-            elif isinstance(field_attribute, float):  # we have id(clone_attribute) == id(field_attribute)
-                assert clone_attribute == field_attribute
-                setattr(clone, attribute, field_attribute + 1.0)
-                clone_attribute = getattr(clone, attribute)
-                assert clone_attribute == field_attribute + 1.0
-                assert id(clone_attribute) != id(field_attribute)
-            else:
-                assert id(clone_attribute) != id(field_attribute)  # different addresses in memory
-                assert np.allclose(clone_attribute, field_attribute)  # compare the values
 
     def test_create_stress_field(self):
         X = [0.000, 1.000, 2.000, 3.000, 4.000, 5.000, 6.000, 7.000, 8.000, 9.000]

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -1,6 +1,5 @@
 # Standard and third party libraries
 from collections import namedtuple
-import enum
 import numpy as np
 import pytest
 import random
@@ -638,7 +637,6 @@ class TestStressField:
         poisson_ratio = random.random()
         field = StressField(*strains_for_stress_field_1, 1.0, poisson_ratio)
         assert field.poisson_ratio == pytest.approx(poisson_ratio)
-
 
     def test_create_stress_field(self):
         X = [0.000, 1.000, 2.000, 3.000, 4.000, 5.000, 6.000, 7.000, 8.000, 9.000]


### PR DESCRIPTION
Work done:
- [x] deleted `ScalarFieldSample.clone` and `StrainField.clone`
- [x] deleted unit tests associated with `ScalarFieldSample.clone` and `StrainField.clone`

Closes #559