### PR TITLE
Switch from StressField is a ScalarFieldSample to StrainField has a ScalarFieldSample

### DIFF
--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -684,6 +684,10 @@ class StressField:
         return self._strain33
 
     @property
+    def point_list(self):
+        return self._field.point_list
+
+    @property
     def youngs_modulus(self):
         return self._youngs_modulus
 

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -622,7 +622,7 @@ class Direction(Enum):
                 raise KeyError('Cannot determine direction type from "{}"'.format(direction))
 
 
-class StressField(ScalarFieldSample):
+class StressField:
     def __init__(self, strain11, strain22, strain33, youngs_modulus: float, poisson_ratio: float,
                  stress_type=StressType.DIAGONAL) -> None:
         self.direction = Direction.X  # as good of a default as any
@@ -668,8 +668,8 @@ class StressField(ScalarFieldSample):
         x = strain11.point_list.vx
         y = strain11.point_list.vy
         z = strain11.point_list.vz
-        # TODO need to fix up super.__init__ to not need the copy
-        return super().__init__('stress', self.values, self.errors, x, y, z)
+
+        self._field = ScalarFieldSample('stress', self.values, self.errors, x, y, z)
 
     @property
     def get_strain11(self):

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -629,6 +629,15 @@ def stress_samples(strains_for_stress_field_1):
 
 class TestStressField:
 
+    def test_point_list(self, strains_for_stress_field_1):
+        r"""Test point_list property"""
+        vx = [0.000, 1.000, 2.000, 3.000, 4.000, 5.000, 6.000, 7.000, 8.000, 9.000]
+        vy = [0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000]
+        vz = [0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000]
+        coordinates = np.array([vx, vy, vz]).T
+        field = StressField(*strains_for_stress_field_1, 1.0, 1.0)
+        np.allclose(field.point_list.coordinates, coordinates)
+
     def test_youngs_modulus(self, strains_for_stress_field_1):
         r"""Test poisson_ratio property"""
         youngs_modulus = random.random()


### PR DESCRIPTION
Work done:
- [x] `StressField` inherits from `ScalarFieldSample` no more
- [x] implement property `StressField.point_list`
- [x] unit test for property `StressField.point_list`

Closes #562