### PR TITLE
Turn stress components in StressField to ScalarFieldSamples

### DIFF
--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -70,7 +70,7 @@ class ScalarFieldSample:
         return unumpy.std_devs(self._sample)
 
     @property
-    def sample(self):
+    def sample(self) -> np.ndarray:
         r"""
         Uncertainties arrays containing both values and errors.
 

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -906,8 +906,8 @@ class StressField:
         self._initialize_stress_fields(stress11, stress22, stress33)
 
         # At any given time, the StresField object selects one of 11, 22, and 33 directions
-        self.direction, self._stress_selected = None, None
-        self.select(Direction.X)
+        self.direction, self._stress_selected, self._strain_selected = None, None, None
+        self.select(Direction.X)  # initialize the selected direction
 
     def _initialize_stress_fields(self, stress11, stress22, stress33):
         for stress, attr in zip((stress11, stress22, stress33), ('stress11', 'stress22', 'stress33')):
@@ -1009,18 +1009,14 @@ class StressField:
 
     @property
     def strain(self) -> StrainField:
-        if self.direction == Direction.X:
-            return self._strain11
-        elif self.direction == Direction.Y:
-            return self._strain22
-        elif self.direction == Direction.Z:
-            return self._strain33
-        return StrainField()
+        return self._strain_selected
 
     def select(self, direction: str):
         self.direction = Direction.get(direction)
         direction_to_stress = {Direction.X: self.stress11, Direction.Y: self.stress22, Direction.Z: self.stress33}
+        direction_to_strain = {Direction.X: self._strain11, Direction.Y: self._strain22, Direction.Z: self._strain33}
         self._stress_selected = direction_to_stress[self.direction]
+        self._strain_selected = direction_to_strain[self.direction]
 
 
 def stack_scalar_field_samples(*fields,
@@ -1086,7 +1082,7 @@ def stack_scalar_field_samples(*fields,
 
     # We cluster the aggregated sample points according to euclidean distance. Points within
     # one cluster have mutual distances below resolution, so they can be considered the same sample point.
-==    # We will associate a "common point" to each cluster, wich is the geometrical center
+    # We will associate a "common point" to each cluster, wich is the geometrical center
     # of all the points in the cluster.
     # Each cluster amounts to one common point that can be resolved from the the sample points belonging
     # to other clusters.

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -1001,22 +1001,24 @@ class StressField:
 
     @property
     def values(self) -> np.ndarray:
+        assert self._stress_selected, 'No direction has yet been selected'
         return self._stress_selected.values
 
     @property
     def errors(self) -> np.ndarray:
+        assert self._stress_selected, 'No direction has yet been selected'
         return self._stress_selected.errors
 
     @property
-    def strain(self) -> StrainField:
+    def strain(self) -> Optional[StrainField]:
         return self._strain_selected
 
-    def select(self, direction: str):
+    def select(self, direction: Union[Direction, str]):
         self.direction = Direction.get(direction)
         direction_to_stress = {Direction.X: self.stress11, Direction.Y: self.stress22, Direction.Z: self.stress33}
         direction_to_strain = {Direction.X: self._strain11, Direction.Y: self._strain22, Direction.Z: self._strain33}
-        self._stress_selected = direction_to_stress[self.direction]
-        self._strain_selected = direction_to_strain[self.direction]
+        self._stress_selected = direction_to_stress[self.direction]  # type: ignore
+        self._strain_selected = direction_to_strain[self.direction]  # type: ignore
 
 
 def stack_scalar_field_samples(*fields,

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -70,6 +70,17 @@ class ScalarFieldSample:
         return unumpy.std_devs(self._sample)
 
     @property
+    def sample(self):
+        r"""
+        Uncertainties arrays containing both values and errors.
+
+        Returns
+        -------
+        ~unumpy.array
+        """
+        return self._sample
+
+    @property
     def point_list(self) -> PointList:
         return self._point_list
 
@@ -502,6 +513,19 @@ class StrainField:
         return len(self._field)
 
     def __mul__(self, other):
+        r"""
+        Stack this strain with another strain, or with a list of strains
+
+        Parameters
+        ----------
+        other: ~pyrs.dataobjects.fields.StrainField, list
+            If a list, each item is a ~pyrs.dataobjects.fields.StrainField object
+
+        Returns
+        -------
+        list
+            list of stacked ~pyrs.dataobjects.fields.StrainField objects.
+        """
         stack_kwargs = dict(resolution=DEFAULT_POINT_RESOLUTION, stack_mode='complete')
         if isinstance(other, StrainField):
             return self.__class__.stack_strains(self, other, **stack_kwargs)
@@ -510,6 +534,27 @@ class StrainField:
                 if isinstance(strain, StrainField) is False:
                     raise TypeError(f'{strain} is not a {str(self.__class__)} object')
             return self.__class__.stack_strains(self, *other, **stack_kwargs)
+
+    def __rmul__(self, other):
+        r"""
+        Stack a list of strains along with this strain.
+
+        Parameters
+        ----------
+        other: list
+            Each item is a ~pyrs.dataobjects.fields.StrainField object.
+
+        Return
+        ------
+        list
+            List of stacked strains. Each item is a ~pyrs.dataobjects.fields.StrainField object.
+        """
+        stack_kwargs = dict(resolution=DEFAULT_POINT_RESOLUTION, stack_mode='complete')
+        if isinstance(other, (list, tuple)):
+            for strain in other:
+                if isinstance(strain, StrainField) is False:
+                    raise TypeError(f'{strain} is not a {str(self.__class__)} object')
+            return self.__class__.stack_strains(*other, self, **stack_kwargs)
 
     @property
     def filenames(self):
@@ -552,6 +597,21 @@ class StrainField:
     @property
     def errors(self):
         return self._field.errors
+
+    @property
+    def sample(self):
+        r"""
+        Uncertainties arrays containing both values and errors.
+
+        Returns
+        -------
+        ~unumpy.array
+        """
+        return self._field.sample
+
+    @property
+    def point_list(self):
+        return self._field.point_list
 
     @property
     def x(self):
@@ -828,38 +888,80 @@ class Direction(Enum):
 
 class StressField:
 
-    def __init__(self, strain11, strain22, strain33, youngs_modulus: float, poisson_ratio: float,
+    def __init__(self, strain11, strain22, strain33,
+                 youngs_modulus: float, poisson_ratio: float,
                  stress_type=StressType.DIAGONAL) -> None:
 
-        self.direction = Direction.X  # as good of a default as any
+        self.stress11, self.stress22, self.stress33 = None, None, None
+
         self._youngs_modulus = youngs_modulus
         self._poisson_ratio = poisson_ratio
 
-        # Stack strains and set references to strain directions
+        # Stack strains
         self.stress_type = StressType.get(stress_type)
-        self._strain11, self._strain22, self._strain33 = self.stack_strains(strain11, strain22, strain33)\
+        self._strain11, self._strain22, self._strain33 = self._stack_strains(strain11, strain22, strain33)
 
+        # Calculate stress fields, and strain33 if stress_type=StressType.IN_PLANE_STRESS
+        stress11, stress22, stress33 = self._calc_stress_strain()  # returns unumpy.array objects
+        self._initialize_stress_fields(stress11, stress22, stress33)
 
-        # extract strain values - these are the epsilons in the equations
-        # currently assumes all strains are parallel
-        epsilon11 = unumpy.uarray(strain11.values, strain11.errors)
-        epsilon22 = unumpy.uarray(strain22.values, strain22.errors)
+        # At any given time, the StresField object selects one of 11, 22, and 33 directions
+        self.direction, self._stress_selected = None, None
+        self.select(Direction.X)
+
+    def _initialize_stress_fields(self, stress11, stress22, stress33):
+        for stress, attr in zip((stress11, stress22, stress33), ('stress11', 'stress22', 'stress33')):
+            values, errors = unumpy.nominal_values(stress), unumpy.std_devs(stress)
+            setattr(self, attr, ScalarFieldSample('stress', values, errors, self.x, self.y, self.z))
+
+    def _calc_stress_strain(self):
+        r"""
+        Calculate the values and errors for each of the diagonal stress fields
+
+        Returns
+        -------
+        list
+            Each item is a ~unumpy.array object, corresponding to the values and error for one of the stress fields
+        """
+        youngs_modulus, poisson_ratio = self.youngs_modulus, self.poisson_ratio
+        prefactor = youngs_modulus / (1 + poisson_ratio)
+
+        strain11, strain22 = self._strain11.sample, self._strain22.sample  # unumpy.arrays
+        sample_zero = unumpy.uarray(np.zeros(self.size, dtype=float), np.zeros(self.size, dtype=float))
+
+        # calculate the additive trace
         if self.stress_type == StressType.DIAGONAL:
-            epsilon33 = unumpy.uarray(strain33.values, strain33.errors)
+            strain33 = self._strain33.sample
+        else:
+            strain33 = sample_zero
+        f = 1.0 if self.stress_type == StressType.IN_PLANE_STRESS else 2.0
+        additive = poisson_ratio * (strain11 + strain22 + strain33) / (1 - f * poisson_ratio)
 
-        # calculate stress
-        if self.stress_type == StressType.DIAGONAL:
-            self.__calc_diagonal_stress(youngs_modulus, poisson_ratio, epsilon11, epsilon22, epsilon33)
-        elif self.stress_type == StressType.IN_PLANE_STRAIN:
-            self.__calc_in_plane_strain(youngs_modulus, poisson_ratio, epsilon11, epsilon22)
+        # Calculate the stresses
+        stress11 = prefactor * (strain11 + additive)
+        stress22 = prefactor * (strain22 + additive)
+        if self.stress_type in (StressType.DIAGONAL, StressType.IN_PLANE_STRAIN):
+            stress33 = prefactor * (strain33 + additive)
         elif self.stress_type == StressType.IN_PLANE_STRESS:
-            self.__calc_in_plane_stress(youngs_modulus, poisson_ratio,  epsilon11, epsilon22)
+            stress33 = sample_zero
         else:
             raise ValueError('Cannot calculate stress of type {}'.format(self.stress_type))
 
-    def stack_strains(self, strain11, strain22, strain33):
+        return stress11, stress22, stress33
+
+    def _stack_strains(self, strain11, strain22, strain33):
         if self.stress_type == StressType.DIAGONAL:
             return strain11 * strain22 * strain33
+        return strain11 * strain22 + [None]  # strain33 is yet undefined, so it's assigned a value of `None`
+
+    @property
+    def size(self):
+        r"""Total number of sampling points"""
+        return len(self._strain11)
+
+    @property
+    def point_list(self):
+        return self._strain11.point_list
 
     @property
     def x(self):
@@ -872,6 +974,10 @@ class StressField:
     @property
     def z(self):
         return self._strain11.z
+
+    @property
+    def coordinates(self):
+        return self._strain11.coordinates
 
     @property
     def diagonal_strains(self):
@@ -893,62 +999,13 @@ class StressField:
     def poisson_ratio(self):
         return self._poisson_ratio
 
-    def __calc_diagonal_stress_v2(self):
-        prefactor = self.youngs_modulus / (1 + self.poisson_ratio)
-        # `strain.sample` below is a unumpy.array object
-        strain_tensor_trace = sum([strain.sample for strain in self.diagonal_strains])
-        additive = self.poisson_ratio * strain_tensor_trace / (1 - 2 * self.poisson_ratio)
-        # Create a ScalarField for each stress diagonal
-        for attr, strain in zip(('stress11', 'stress22', 'stress22'), self.diagonal_strains):
-            stress_sample = prefactor * (strain.sample + additive)  # values an errors as unumpy.array
-            values, errors = unumpy.nominal_values(stress_sample), unumpy.std_devs(stress_sample)
-            stress_field = ScalarFieldSample(values, errors, self.x, self.y, self.z)
-            setattr(self, attr, stress_field)
-
-    def __calc_diagonal_stress(self, youngs_modulus, poisson_ratio, strain11, strain22, strain33):
-        prefactor = youngs_modulus / (1 + poisson_ratio)
-        additive = poisson_ratio * (strain11 + strain22 + strain33) / (1 - 2 * poisson_ratio)
-
-        self.stress11 = prefactor * (strain11 + additive)
-        self.stress22 = prefactor * (strain22 + additive)
-        self.stress33 = prefactor * (strain33 + additive)
-
-    def __calc_in_plane_strain(self, youngs_modulus, poisson_ratio, strain11, strain22):
-        '''This assumes strain in the 33 direction (epsilon33) is zero'''
-        prefactor = youngs_modulus / (1 + poisson_ratio)
-        additive = poisson_ratio * (strain11 + strain22) / (1 - 2 * poisson_ratio)
-
-        self.stress11 = prefactor * (strain11 + additive)
-        self.stress22 = prefactor * (strain22 + additive)
-        self.stress33 = prefactor * additive
-
-    def __calc_in_plane_stress(self, youngs_modulus, poisson_ratio, strain11, strain22):
-        '''This assumes stress in the 33 direction (sigma33) is zero'''
-        prefactor = youngs_modulus / (1 + poisson_ratio)
-        additive = poisson_ratio * (strain11 + strain22) / (1 - poisson_ratio)
-
-        self.stress11 = prefactor * (strain11 + additive)
-        self.stress22 = prefactor * (strain22 + additive)
-        length = len(strain11)  # assumed to be zero
-        self.stress33 = unumpy.uarray(np.zeros(length, dtype=float), np.zeros(length, dtype=float))
-
     @property
     def values(self) -> np.ndarray:
-        if self.direction == Direction.X:
-            return unumpy.nominal_values(self.stress11)
-        elif self.direction == Direction.Y:
-            return unumpy.nominal_values(self.stress22)
-        elif self.direction == Direction.Z:
-            return unumpy.nominal_values(self.stress33)
+        return self._stress_selected.values
 
     @property
     def errors(self) -> np.ndarray:
-        if self.direction == Direction.X:
-            return unumpy.std_devs(self.stress11)
-        elif self.direction == Direction.Y:
-            return unumpy.std_devs(self.stress22)
-        elif self.direction == Direction.Z:
-            return unumpy.std_devs(self.stress33)
+        return self._stress_selected.errors
 
     @property
     def strain(self) -> StrainField:
@@ -962,6 +1019,8 @@ class StressField:
 
     def select(self, direction: str):
         self.direction = Direction.get(direction)
+        direction_to_stress = {Direction.X: self.stress11, Direction.Y: self.stress22, Direction.Z: self.stress33}
+        self._stress_selected = direction_to_stress[self.direction]
 
 
 def stack_scalar_field_samples(*fields,

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -669,7 +669,7 @@ def test_generateParameterField(test_data_dir):
     np.testing.assert_almost_equal(dim_z.getMinimum(), -15)
     np.testing.assert_almost_equal(dim_z.getMaximum(), 15)
     signal = center_md.getSignalArray()
-    np.testing.assert_almost_equal(signal.min(), 89.94798, decimal=5)
+    np.testing.assert_almost_equal(signal.min(), 89.94377, decimal=5)
     np.testing.assert_almost_equal(signal.max(), 90.15296, decimal=5)
     errors = center_md.getErrorSquaredArray()
     np.testing.assert_almost_equal(errors.min(), 0.02019792)

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -669,7 +669,7 @@ def test_generateParameterField(test_data_dir):
     np.testing.assert_almost_equal(dim_z.getMinimum(), -15)
     np.testing.assert_almost_equal(dim_z.getMaximum(), 15)
     signal = center_md.getSignalArray()
-    np.testing.assert_almost_equal(signal.min(), 89.94377, decimal=5)
+    np.testing.assert_almost_equal(signal.min(), 89.94798, decimal=5)
     np.testing.assert_almost_equal(signal.max(), 90.15296, decimal=5)
     errors = center_md.getErrorSquaredArray()
     np.testing.assert_almost_equal(errors.min(), 0.02019792)
@@ -706,18 +706,23 @@ def strains_for_stress_field_1():
     Z = [0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000]
     # selected to make terms drop out
 
-    sample11 = ScalarFieldSample('strain',
-                                 [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.080, 0.009],  # values
-                                 [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],  # errors
-                                 X, Y, Z)
-    sample22 = ScalarFieldSample('strain',
-                                 [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.080, 0.009],  # values
-                                 [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],  # errors
-                                 X, Y, Z)
-    sample33 = ScalarFieldSample('strain',
-                                 [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.080, 0.009],  # values
-                                 [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],  # errors
-                                 X, Y, Z)
+    def strain_instantiator(name, values, errors, x, y, z):
+        strain = StrainField()
+        strain._field = ScalarFieldSample(name, values, errors, x, y, z)
+        return strain
+
+    sample11 = strain_instantiator('strain',
+                                   [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.080, 0.009],  # values
+                                   [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],  # errors
+                                   X, Y, Z)
+    sample22 = strain_instantiator('strain',
+                                   [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.080, 0.009],  # values
+                                   [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],  # errors
+                                   X, Y, Z)
+    sample33 = strain_instantiator('strain',
+                                   [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.080, 0.009],  # values
+                                   [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],  # errors
+                                   X, Y, Z)
     return sample11, sample22, sample33
 
 
@@ -738,7 +743,7 @@ class TestStressField:
         vz = [0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000]
         coordinates = np.array([vx, vy, vz]).T
         field = StressField(*strains_for_stress_field_1, 1.0, 1.0)
-        np.allclose(field.point_list.coordinates, coordinates)
+        np.allclose(field.coordinates, coordinates)
 
     def test_youngs_modulus(self, strains_for_stress_field_1):
         r"""Test poisson_ratio property"""
@@ -752,24 +757,29 @@ class TestStressField:
         field = StressField(*strains_for_stress_field_1, 1.0, poisson_ratio)
         assert field.poisson_ratio == pytest.approx(poisson_ratio)
 
-    def test_create_stress_field(self):
+    def test_create_stress_field(self, allclose_with_sorting):
         X = [0.000, 1.000, 2.000, 3.000, 4.000, 5.000, 6.000, 7.000, 8.000, 9.000]
         Y = [0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000]
         Z = [0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000, 0.000]
         # selected to make terms drop out
 
-        sample11 = ScalarFieldSample('strain',
-                                     [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.080, 0.009],  # values
-                                     [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],  # errors
-                                     X, Y, Z)
-        sample22 = ScalarFieldSample('strain',
-                                     [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.080, 0.009],  # values
-                                     [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],  # errors
-                                     X, Y, Z)
-        sample33 = ScalarFieldSample('strain',
-                                     [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.080, 0.009],  # values
-                                     [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],  # errors
-                                     X, Y, Z)
+        def strain_instantiator(name, values, errors, x, y, z):
+            strain = StrainField()
+            strain._field = ScalarFieldSample(name, values, errors, x, y, z)
+            return strain
+
+        sample11 = strain_instantiator('strain',
+                                       [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],
+                                       [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],
+                                       X, Y, Z)
+        sample22 = strain_instantiator('strain',
+                                       [0.010, 0.011, 0.012, 0.013, 0.014, 0.015, 0.016, 0.017, 0.018, 0.019],
+                                       [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],
+                                       X, Y, Z)
+        sample33 = strain_instantiator('strain',
+                                       [0.020, 0.021, 0.022, 0.023, 0.024, 0.025, 0.026, 0.027, 0.028, 0.029],
+                                       [0.000, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009],
+                                       X, Y, Z)
 
         POISSON = 1. / 3.  # makes nu / (1 - 2*nu) == 1
         YOUNG = 1 + POISSON  # makes E / (1 + nu) == 1
@@ -777,36 +787,37 @@ class TestStressField:
         # test diagonal calculation
         diagonal = StressField(sample11, sample22, sample33, YOUNG, POISSON)
         assert diagonal
+        # check strains
+        assert allclose_with_sorting(diagonal.get_strain11.values, sample11.values)
+        assert allclose_with_sorting(diagonal.get_strain22.values, sample22.values)
+        assert allclose_with_sorting(diagonal.get_strain33.values, sample33.values)
         # check coordinates
-        np.testing.assert_equal(diagonal.point_list.vx, X)
-        np.testing.assert_equal(diagonal.point_list.vy, Y)
-        np.testing.assert_equal(diagonal.point_list.vz, Z)
+        assert allclose_with_sorting(diagonal.x, X)
+        assert allclose_with_sorting(diagonal.y, Y)
+        assert allclose_with_sorting(diagonal.z, Z)
         # check values
         second = (sample11.values + sample22.values + sample33.values)
         diagonal.select('11')
-        np.testing.assert_allclose(diagonal.values, sample11.values + second)
-        assert diagonal.strain == sample11
+        assert allclose_with_sorting(diagonal.values, sample11.values + second)
         diagonal.select('22')
-        np.testing.assert_allclose(diagonal.values, sample22.values + second)
-        assert diagonal.strain == sample22
+        assert allclose_with_sorting(diagonal.values, sample22.values + second)
         diagonal.select('33')
-        np.testing.assert_allclose(diagonal.values, sample33.values + second)
-        assert diagonal.strain == sample33
+        assert allclose_with_sorting(diagonal.values, sample33.values + second)
 
         in_plane_strain = StressField(sample11, sample22, None, YOUNG, POISSON, 'in-plane-strain')
         assert in_plane_strain
         # check coordinates
-        np.testing.assert_equal(in_plane_strain.point_list.vx, X)
-        np.testing.assert_equal(in_plane_strain.point_list.vy, Y)
-        np.testing.assert_equal(in_plane_strain.point_list.vz, Z)
+        assert allclose_with_sorting(in_plane_strain.x, X)
+        assert allclose_with_sorting(in_plane_strain.y, Y)
+        assert allclose_with_sorting(in_plane_strain.z, Z)
         # check values
         second = (sample11.values + sample22.values)
         in_plane_strain.select('11')
-        np.testing.assert_allclose(in_plane_strain.values, sample11.values + second)
+        allclose_with_sorting(in_plane_strain.values, sample11.values + second)
         in_plane_strain.select('22')
-        np.testing.assert_allclose(in_plane_strain.values, sample22.values + second)
+        allclose_with_sorting(in_plane_strain.values, sample22.values + second)
         in_plane_strain.select('33')
-        np.testing.assert_allclose(in_plane_strain.values, second)
+        allclose_with_sorting(in_plane_strain.values, second)
 
         # redefine values to simplify things
         POISSON = 1. / 2.  # makes nu / (1 - nu) == 1
@@ -815,18 +826,18 @@ class TestStressField:
         in_plane_stress = StressField(sample11, sample22, None, YOUNG, POISSON, 'in-plane-stress')
         assert in_plane_stress
         # check coordinates
-        np.testing.assert_equal(in_plane_stress.point_list.vx, X)
-        np.testing.assert_equal(in_plane_stress.point_list.vy, Y)
-        np.testing.assert_equal(in_plane_stress.point_list.vz, Z)
+        assert allclose_with_sorting(in_plane_stress.point_list.vx, X)
+        assert allclose_with_sorting(in_plane_stress.point_list.vy, Y)
+        assert allclose_with_sorting(in_plane_stress.point_list.vz, Z)
         # check values
         second = (sample11.values + sample22.values)
         in_plane_stress.select('11')
-        np.testing.assert_allclose(in_plane_stress.values, sample11.values + second)
+        assert allclose_with_sorting(in_plane_stress.values, sample11.values + second)
         in_plane_stress.select('22')
-        np.testing.assert_allclose(in_plane_stress.values, sample22.values + second)
+        assert allclose_with_sorting(in_plane_stress.values, sample22.values + second)
         in_plane_stress.select('33')
-        np.testing.assert_equal(in_plane_stress.values, 0.)
-        np.testing.assert_equal(in_plane_stress.errors, 0.)
+        assert allclose_with_sorting(in_plane_stress.values, 0.)
+        assert allclose_with_sorting(in_plane_stress.errors, 0.)
 
 
 @pytest.fixture(scope='module')

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -788,9 +788,9 @@ class TestStressField:
         diagonal = StressField(sample11, sample22, sample33, YOUNG, POISSON)
         assert diagonal
         # check strains
-        assert allclose_with_sorting(diagonal.get_strain11.values, sample11.values)
-        assert allclose_with_sorting(diagonal.get_strain22.values, sample22.values)
-        assert allclose_with_sorting(diagonal.get_strain33.values, sample33.values)
+        for direction, sample in zip(('11', '22', '33'), (sample11, sample22, sample33)):
+            diagonal.select(direction)
+            assert allclose_with_sorting(diagonal.strain.values, sample.values)
         # check coordinates
         assert allclose_with_sorting(diagonal.x, X)
         assert allclose_with_sorting(diagonal.y, Y)


### PR DESCRIPTION
Work done:
- [x] stack strains
- [x] introduce currently selectd strain and stress
- [x] refactor calculation of stresses
- [x] stresses are now `ScalarFieldSample` objects
- [x] Fix unit tests after refactoring

Closes #574 