### PR TITLE
Export StrainField and StressField to MDHistoWorkspace with linear intepolation

### DIFF
--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -807,7 +807,6 @@ class StrainField:
         -------
         MDHistoWorkspace
         """
-        method = 'nearest'  # TODO remove this line to allow interpolation issue #586
         export_kwags = dict(units=units, interpolate=interpolate, method=method, fill_value=fill_value,
                             keep_nan=keep_nan, resolution=resolution, criterion=criterion)
         return self._field.to_md_histo_workspace(name, **export_kwags)  # type: ignore
@@ -1100,7 +1099,6 @@ class StressField:
         -------
         MDHistoWorkspace
         """
-        method = 'nearest'  # TODO remove this line to allow interpolation issue #586
         export_kwags = dict(units=units, interpolate=interpolate, method=method, fill_value=fill_value,
                             keep_nan=keep_nan, resolution=resolution, criterion=criterion)
         return self._stress_selected.to_md_histo_workspace(name, **export_kwags)  # type: ignore

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -356,7 +356,7 @@ class ScalarFieldSample:
             sample = self
         extents = sample.point_list.extents(resolution=resolution)  # triad of DirectionExtents objects
         for extent in extents:
-            assert extent[0] < extent[1], f'min value of {extent} is not smaller than max value'
+            assert extent[0] <= extent[1], f'min value of {extent} is greater than max value'
         extents_str = ','.join([extent.to_createmd for extent in extents])
 
         units_triad = ','.join([units] * 3)  # 'meter,meter,meter'

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -645,6 +645,7 @@ class TestStrainField:
             assert dimension.getMaximum() == pytest.approx(max_value, abs=1.e-02)
             assert dimension.getNBins() == bin_count
 
+
 def test_generateParameterField(test_data_dir):
     file_path = os.path.join(test_data_dir, 'HB2B_1320.h5')
 

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -631,6 +631,19 @@ class TestStrainField:
         assert strain1_stacked.peak_collection == strain1.peak_collection
         assert strain23_stacked.peak_collections == [strain2.peak_collection, strain3.peak_collection]
 
+    def test_to_md_histo_workspace(self, strain_field_samples):
+        strain = strain_field_samples['HB2B_1320_peak0']
+        histo = strain.to_md_histo_workspace(method='linear', resolution=DEFAULT_POINT_RESOLUTION)
+        assert histo.id() == 'MDHistoWorkspace'
+        minimum_values = (-31.76, -7.20, -15.00)
+        maximum_values = (31.76, 7.20, 15.00)
+        bin_counts = (18, 6, 3)
+        for i, (min_value, max_value, bin_count) in enumerate(zip(minimum_values, maximum_values, bin_counts)):
+            dimension = histo.getDimension(i)
+            assert dimension.getUnits() == 'meter'
+            assert dimension.getMinimum() == pytest.approx(min_value, abs=1.e-02)
+            assert dimension.getMaximum() == pytest.approx(max_value, abs=1.e-02)
+            assert dimension.getNBins() == bin_count
 
 def test_generateParameterField(test_data_dir):
     file_path = os.path.join(test_data_dir, 'HB2B_1320.h5')
@@ -838,6 +851,11 @@ class TestStressField:
         in_plane_stress.select('33')
         assert allclose_with_sorting(in_plane_stress.values, 0.)
         assert allclose_with_sorting(in_plane_stress.errors, 0.)
+
+    def test_to_md_histo_workspace(self, stress_samples):
+        stress = stress_samples['stress diagonal']
+        histo = stress.to_md_histo_workspace(method='linear')
+        assert histo.id() == 'MDHistoWorkspace'
 
 
 @pytest.fixture(scope='module')

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -635,9 +635,9 @@ class TestStrainField:
         strain = strain_field_samples['HB2B_1320_peak0']
         histo = strain.to_md_histo_workspace(method='linear', resolution=DEFAULT_POINT_RESOLUTION)
         assert histo.id() == 'MDHistoWorkspace'
-        minimum_values = (-31.76, -7.20, -15.00)
-        maximum_values = (31.76, 7.20, 15.00)
-        bin_counts = (18, 6, 3)
+        minimum_values = (-31.76, -7.20, -15.00)  # bin boundary with the smallest coordinate along X, Y, and Z
+        maximum_values = (31.76, 7.20, 15.00)  # bin boundary with the largest coordinate along X, Y, and Z
+        bin_counts = (18, 6, 3)  # number of bins along  X, Y, and Z
         for i, (min_value, max_value, bin_count) in enumerate(zip(minimum_values, maximum_values, bin_counts)):
             dimension = histo.getDimension(i)
             assert dimension.getUnits() == 'meter'
@@ -854,8 +854,17 @@ class TestStressField:
 
     def test_to_md_histo_workspace(self, stress_samples):
         stress = stress_samples['stress diagonal']
-        histo = stress.to_md_histo_workspace(method='linear')
+        histo = stress.to_md_histo_workspace(method='linear', resolution=DEFAULT_POINT_RESOLUTION)
+        minimum_values = (-0.5, -0.0005, -0.0005)  # bin boundary with the smallest coordinate along X, Y, and Z
+        maximum_values = (9.5, 0.0005, 0.0005)  # bin boundary with the largest coordinate along X, Y, and Z
+        bin_counts = (10, 1, 1)  # number of bins along  X, Y, and Z
         assert histo.id() == 'MDHistoWorkspace'
+        for i, (min_value, max_value, bin_count) in enumerate(zip(minimum_values, maximum_values, bin_counts)):
+            dimension = histo.getDimension(i)
+            assert dimension.getUnits() == 'meter'
+            assert dimension.getMinimum() == pytest.approx(min_value, abs=1.e-02)
+            assert dimension.getMaximum() == pytest.approx(max_value, abs=1.e-02)
+            assert dimension.getNBins() == bin_count
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Work done:
- [x] Linear interpolation is now the default exporting method
- [x] unit test for StrainField.to_md_histo_workspace
- [x] unit test for StressField.to_md_histo_workspace

Closes #586