### PR TITLE
Fix bug in finding copying the filenames when stacking

### DIFF
--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -557,6 +557,7 @@ class StrainField:
             strain_stacked._field = field_stacked
             strain_stacked._peak_collection = strain._peak_collection
             strain_stacked._single_scans = strain._single_scans
+            strain_stacked._filenames = strain.filenames[:]
             strains_stacked.append(strain_stacked)
         return strains_stacked
 
@@ -574,6 +575,7 @@ class StrainField:
         # when the strain is composed of more than one scan, we keep references to them
         self._single_scans: List['StrainField'] = []
         self._field = field_sample
+        self._filenames: List[str] = []
 
         # Create a strain field from a single scan, if so requested
         single_scan_kwargs = dict(filename=filename, projectfile=projectfile, peak_tag=peak_tag,
@@ -1029,11 +1031,11 @@ class StressField:
     - in plane stress: the stress along the third direction is, by definition, zero.
 
     The formulas for the calculation of the stress for the different types of sampling are:
-    
+
     Diagonal (:math:`i` runs from 1 to 3):
     .. math:
         \sigma_{ii} = \frac{E}{1 + \nu} \left( \epsilon_{ii} + \frac{\nu}{1 - 2 \nu} (\epsilon_{11} + \epsilon_{22} + \epsilon_{33}) \right)
-        
+
     In plane strain (:math:`i` runs from 1 to 3):
     .. math:
         \sigma_{ii} = \frac{E}{1 + \nu} \left( \epsilon_{ii} + \frac{\nu}{1 - 2 \nu} (\epsilon_{11} + \epsilon_{22}) \right(

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -614,22 +614,30 @@ class TestStrainField:
     def test_stack_strains(self, strain_field_samples, allclose_with_sorting):
         strain1 = strain_field_samples['HB2B_1320_peak0']
         strain2 = strain_field_samples['HB2B_1320_']
+
         # Stack two strains having the same evaluation points.
         strain1_stacked, strain2_stacked = strain1 * strain2  # default resolution and stacking mode
         for strain in (strain1_stacked, strain2_stacked):
             assert len(strain) == len(strain1)
             assert bool(np.all(np.isfinite(strain.values))) is True  # all points are common to strain1 and strain2
+
         # Stack two strains having completely different evaluation points.
         strain3 = strain_field_samples['strain with two points per direction']
         strain2_stacked, strain3_stacked = strain2 * strain3  # default resolution and stacking mode
         # The common list of points is the sum of the points from each strain
         for strain in (strain2_stacked, strain3_stacked):
             assert len(strain) == len(strain2) + len(strain3)
+
+        # verify the filenames got copied over
+        for strain_stacked, strain in ((strain2_stacked, strain2), (strain3_stacked, strain3)):
+            assert strain_stacked.filenames == strain.filenames
+
         # There's no common point that is common to both strain2 and strain3
         # Each stacked strain only have finite measurements on points coming from the un-stacked strain
         for strain_stacked, strain in ((strain2_stacked, strain2), (strain3_stacked, strain3)):
             finite_measurements_count = len(np.where(np.isfinite(strain_stacked.values))[0])
             assert finite_measurements_count == len(strain)
+
         # The points evaluated as 'nan' must come from the other scan
         for strain_stacked, strain_other in ((strain2_stacked, strain3), (strain3_stacked, strain2)):
             nan_measurements_count = len(np.where(np.isnan(strain_stacked.values))[0])


### PR DESCRIPTION
The name was not set in the `__init__` function and was not being copied in the `stack_strain` method.

Fixes #601