### PR TITLE
Add test data with multiple griding for StressField testing

### DIFF
--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -3,7 +3,7 @@ from enum import unique as unique_enum
 import numpy as np
 from scipy.interpolate import griddata
 from scipy.spatial import cKDTree
-from typing import TYPE_CHECKING, cast, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, cast, Generator, List, Optional, Tuple, Union
 from uncertainties import unumpy
 
 from mantid.simpleapi import mtd, CreateMDWorkspace, BinMD
@@ -1125,7 +1125,7 @@ class StressField:
         assert direction in ('11', '22', '33'), 'The direction is not one of ("11", "22", "33")'
         return getattr(self, f'stress{direction}')
 
-    def __iter__(self) -> ScalarFieldSample:
+    def __iter__(self) -> Generator[ScalarFieldSample]:
         r"""
         Access the stress along the different directions
 
@@ -1326,7 +1326,7 @@ class StressField:
 
     @property
     def strain33(self) -> StrainField:
-        return self._strain33
+        return self._strain33  # type: ignore
 
     @property
     def youngs_modulus(self) -> float:

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -3,7 +3,7 @@ from enum import unique as unique_enum
 import numpy as np
 from scipy.interpolate import griddata
 from scipy.spatial import cKDTree
-from typing import TYPE_CHECKING, cast, Generator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, cast, Iterator, List, Optional, Tuple, Union
 from uncertainties import unumpy
 
 from mantid.simpleapi import mtd, CreateMDWorkspace, BinMD
@@ -1125,7 +1125,7 @@ class StressField:
         assert direction in ('11', '22', '33'), 'The direction is not one of ("11", "22", "33")'
         return getattr(self, f'stress{direction}')
 
-    def __iter__(self) -> Generator[ScalarFieldSample]:
+    def __iter__(self) -> Iterator[ScalarFieldSample]:
         r"""
         Access the stress along the different directions
 

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -1031,6 +1031,7 @@ class Direction(Enum):
         one_to_two = dict(x='11', y='22', z='33')
         return one_to_two[self.value]
 
+
 class StressField:
     r"""
     Calculate the three diagonal components of the stress tensor, assuming a diagonal strain tensor.

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -1136,7 +1136,7 @@ class StressField:
         ~pyrs.dataobjects.fields.ScalarFieldSample
         """
         for stress_component in (self.stress11, self.stress22, self.stress33):
-            yield stress_component
+            yield stress_component  # type: ignore
 
     def _initialize_stress_fields(self, stress11: np.ndarray, stress22: np.ndarray, stress33: np.ndarray) -> None:
         r"""

--- a/tests/integration/pyrs/dataobjects/test_fields.py
+++ b/tests/integration/pyrs/dataobjects/test_fields.py
@@ -3,7 +3,7 @@ from os.path import join as pjoin
 import pytest
 
 from pyrs.dataobjects.constants import DEFAULT_POINT_RESOLUTION
-from pyrs.dataobjects.fields import ScalarFieldSample, fuse_scalar_field_samples, StrainField
+from pyrs.dataobjects.fields import fuse_scalar_field_samples, ScalarFieldSample, StrainField, StressField
 
 
 @pytest.fixture(scope='module')
@@ -186,6 +186,7 @@ def test_interpolate_volume_scan(data_interpolate_volume_scan, allclose_with_sor
 # Integration tests involving strains #
 #######################################
 
+
 def test_combine_strains_1(test_data_dir):
     r"""Combine strains along the same direction with StrainField.fuse_strains"""
     #
@@ -225,6 +226,87 @@ def test_combine_strains_1(test_data_dir):
     assert len(signal.ravel()) == 2793
     assert len(np.where(np.isnan(signal))[0]) == 1552  # number of nan
     assert bool(np.all(np.isnan(signal) == np.isnan(errors)))  # if the value is nan at a point, the error is nan too
+
+@pytest.fixture(scope='session')
+def data_stack_strains_1(test_data_dir):
+    #
+    # Load the individual strains from the project files
+    file_names = [f'HB2B_{run_number}.h5' for run_number in (1331, 1332, 1327, 1328)]
+    strains = [StrainField(filename=pjoin(test_data_dir, file_name), peak_tag='peak0') for file_name in file_names]
+    #
+    # Combine strains strain11, strain22, strain33 objects.
+    # strain11, strain22, strain33 are defined on sets of samples that overlap partially
+    strain11 = strains[0] + strains[2] + strains[3]  # all but strains[1]
+    strain22 = strains[0] + strains[1] + strains[3]  # all but strains[2]
+    strain33 = strains[0] + strains[1] + strains[2]  # all but strains[3]
+    return strains, strain11, strain22, strain33
+
+
+def test_stack_strains_1(data_stack_strains_1):
+    strains, strain11, strain22, strain33 = data_stack_strains_1
+    #
+    # Stack strains
+    strain11, strain22, strain33 = strain11 * strain22 * strain33
+    #
+    # The number of nan on each strain_ii should be the length of strains[i] because strains[i] is the missing one
+    assert len(np.where(np.isnan(strain11.values))[0]) == len(strains[1]) - 1  # there's an overlap of only one point
+    assert len(np.where(np.isnan(strain22.values))[0]) == len(strains[2])
+    assert len(np.where(np.isnan(strain33.values))[0]) == len(strains[3])
+    assert strain11.point_list == strain22.point_list
+    assert strain22.point_list == strain33.point_list
+
+    
+@pytest.fixture(scope='session')
+def data_create_stress_1(test_data_dir):
+    #
+    # Load the individual strains from the project files
+    file_names = [f'HB2B_{run_number}.h5' for run_number in (1331, 1332, 1327, 1328)]
+    strains = [StrainField(filename=pjoin(test_data_dir, file_name), peak_tag='peak0') for file_name in file_names]
+    #
+    # Combine strains strain11, strain22, strain33 objects to ensure overlap of sample points
+    sample_count_total = sum([len(s) for s in strains])
+    strain11 = strains[0] + strains[1] + strains[2] + strains[3]
+    assert len(strain11) == sample_count_total - 1  # strains overlap only in one point
+    strain22 = strains[0] + strains[2] + strains[3]  # all but strains[1] (24 points)
+    assert len(strain22) == sample_count_total - len(strains[1])
+    strain33 = strains[1] + strains[2] + strains[3]  # all but strains[0] (26 points)
+    assert len(strain33) == sample_count_total - len(strains[0])
+    return strain11, strain22, strain33
+
+
+def test_create_stress_1(data_create_stress_1):
+    strain11, strain22, strain33 = data_create_stress_1
+    #
+    # Diagonal stress
+    poisson_ratio = 1. / 3.  # makes nu / (1 - 2*nu) == 1
+    young_modulus = 1 + poisson_ratio  # makes E / (1 + nu) == 1
+    stress = StressField(strain11, strain22, strain33, young_modulus, poisson_ratio)
+    trace = stress.strain11.values + stress.strain22.values + stress.strain33.values
+    assert stress['11'].point_list == stress['22'].point_list
+    assert stress['22'].point_list == stress['33'].point_list
+    assert np.allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
+    assert np.allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
+    assert np.allclose(stress['33'].values, stress.strain33.values + trace, equal_nan=True)
+    #
+    # In-plane strain (strain33 is zero)
+    poisson_ratio = 1. / 3.  # makes nu / (1 - 2*nu) == 1
+    young_modulus = 1 + poisson_ratio  # makes E / (1 + nu) == 1
+    stress = StressField(strain11, strain22, None, young_modulus, poisson_ratio, stress_type='in-plane-strain')
+    trace = stress.strain11.values + stress.strain22.values
+    assert np.allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
+    assert np.allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
+    assert np.allclose(stress['33'].values, trace, equal_nan=True)
+    assert np.all(stress.strain33.values == 0.0)
+    #
+    # In-plane stress (stress33 is zero)
+    poisson_ratio = 0.5
+    young_modulus = 1 + poisson_ratio
+    stress = StressField(strain11, strain22, None, young_modulus, poisson_ratio, stress_type='in-plane-stress')
+    trace = stress.strain11.values + stress.strain22.values
+    assert np.allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
+    assert np.allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
+    assert np.all(stress['33'].values == 0.0)
+    assert np.allclose(stress.strain33.values, -(stress.strain11.values + stress.strain22.values), equal_nan=True)
 
 
 if __name__ == '__main__':

--- a/tests/integration/pyrs/dataobjects/test_fields.py
+++ b/tests/integration/pyrs/dataobjects/test_fields.py
@@ -227,6 +227,7 @@ def test_combine_strains_1(test_data_dir):
     assert len(np.where(np.isnan(signal))[0]) == 1552  # number of nan
     assert bool(np.all(np.isnan(signal) == np.isnan(errors)))  # if the value is nan at a point, the error is nan too
 
+
 @pytest.fixture(scope='session')
 def data_stack_strains_1(test_data_dir):
     #
@@ -255,7 +256,12 @@ def test_stack_strains_1(data_stack_strains_1):
     assert strain11.point_list == strain22.point_list
     assert strain22.point_list == strain33.point_list
 
-    
+
+########################################
+# Integration tests involving stresses #
+########################################
+
+
 @pytest.fixture(scope='session')
 def data_create_stress_1(test_data_dir):
     #


### PR DESCRIPTION
Work done:
- [x] properties `StressField.strain11`, `StressField.strain22`, `StressField.strain33` (and unit test)
- [x] iterator `StressField.__iter__` iterates over the diagonal stress component  (and unit test)
- [x] bracket operator `StressField.__getitem__` fetches the diagonal stress components (and unit test)
- [x] integration test for stacking strains
- [x] integration test for creating stress field in the stress types "diagonal", "in-plane strain" and "in-plane stress"

Closes #528