### PR TITLE
Peak fitting windows - Fix bug in trying to plot in a mpl figure of zero area

### DIFF
--- a/pyrs/interface/peak_fitting/plot.py
+++ b/pyrs/interface/peak_fitting/plot.py
@@ -196,12 +196,16 @@ class Plot:
         else:
 
             self.parent.ui.graphicsView_plot2D.ax = self.parent.ui.graphicsView_plot2D.figure.gca(projection='3d')
-            self.parent.ui.graphicsView_plot2D.ax.scatter(axis_x_data, axis_y_data, axis_z_data)
-            self.parent.ui.graphicsView_plot2D._myCanvas.draw()
 
-            self.parent.ui.graphicsView_plot2D.ax.set_xlabel(x_axis_name)
-            self.parent.ui.graphicsView_plot2D.ax.set_ylabel(y_axis_name)
-            self.parent.ui.graphicsView_plot2D.ax.set_zlabel(z_axis_name)
+            # only try plotting if the figure height is larger than 0
+            fig_size = self.parent.ui.graphicsView_plot2D.figure.get_size_inches()
+            if fig_size[1] > 0:
+                self.parent.ui.graphicsView_plot2D.ax.scatter(axis_x_data, axis_y_data, axis_z_data)
+                self.parent.ui.graphicsView_plot2D._myCanvas.draw()
+
+                self.parent.ui.graphicsView_plot2D.ax.set_xlabel(x_axis_name)
+                self.parent.ui.graphicsView_plot2D.ax.set_ylabel(y_axis_name)
+                self.parent.ui.graphicsView_plot2D.ax.set_zlabel(z_axis_name)
 
     def format_3D_axis_data(self, axis_x=[], axis_y=[], axis_z=[]):
 


### PR DESCRIPTION
When the 3D plot is shrunk to zero size the plotting failed. So don't try to plot if the height is 0.

Fixes #625 