### PR TITLE
Fix bug getting filename from HidraProjectFile

### DIFF
--- a/pyrs/projectfile/file_object.py
+++ b/pyrs/projectfile/file_object.py
@@ -140,7 +140,7 @@ class HidraProjectFile:
         """
         File name on HDD
         """
-        return self._project_h5.name
+        return self._project_h5.filename
 
     def append_raw_counts(self, sub_run_number: int, counts_array: numpy.ndarray) -> None:
         """Add raw detector counts collected in a single scan/Pt

--- a/tests/unit/test_hidra_project_file.py
+++ b/tests/unit/test_hidra_project_file.py
@@ -71,6 +71,9 @@ def test_mask():
     verify_solid_mask = verify_project_file.read_mask_solid_angle('test')
     assert np.allclose(solid_mask, verify_solid_mask, 1.E-2)
 
+    # check name
+    assert verify_project_file.name.endswith('test_mask.hdf')
+
     # Clean
     os.remove('test_mask.hdf')
 
@@ -326,6 +329,9 @@ def test_strain_io():
     verify_d_ref_2, verify_d_err_2 = peak_info2.get_d_reference()
     np.testing.assert_allclose(verify_d_ref_2, test_ref_d2)
     assert np.all(verify_d_err_2 == 0.)
+
+    # check name
+    assert verify_project_file.name.endswith(test_file_name)
 
     # Clean
     os.remove(test_file_name)


### PR DESCRIPTION
Unlike Python file objects, the attribute File.name gives the HDF5 name of the root group, “/”. To access the on-disk name, use File.filename.