### PR TITLE
StrainField get/set d-reference

### DIFF
--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -1186,6 +1186,21 @@ class StrainFieldSingle(_StrainField):
     def errors(self):
         return self._peak_collection.get_strain()[1]
 
+    def _create_scalar_field(self, method, name):
+        # the data is taken from the `PeakCollection`
+        if self._peak_collection is None:
+            raise RuntimeError('PeakCollection has not been set')
+
+        # get the data
+        values, errors = getattr(self._peak_collection, f'{method}')()
+
+        # put it all together into a ScalarFieldSample
+        full_values = np.full(len(self.point_list), NOT_MEASURED_NUMPY, dtype=float)
+        full_errors = np.full(len(self.point_list), NOT_MEASURED_NUMPY, dtype=float)
+        full_values[:values.size] = values
+        full_errors[:errors.size] = errors
+        return ScalarFieldSample(name, full_values, full_errors, self.x, self.y, self.z)
+
     @property
     def field(self) -> ScalarFieldSample:
         r"""
@@ -1201,16 +1216,12 @@ class StrainFieldSingle(_StrainField):
         -------
         ~pyrs.dataobjects.fields.ScalarFieldSample
         """
-        if self._peak_collection is None:
-            raise RuntimeError('PeakCollection has not been set')
-        values, errors = self._peak_collection.get_strain()
-        full_values = np.full(len(self.point_list), NOT_MEASURED_NUMPY, dtype=float)
-        full_errors = np.full(len(self.point_list), NOT_MEASURED_NUMPY, dtype=float)
-        full_values[:values.size] = values
-        full_errors[:errors.size] = errors
-        return ScalarFieldSample('strain', full_values, full_errors, self.x, self.y, self.z)
+        return self._create_scalar_field(method='get_strain', name='strain')
 
     def set_d_reference(self, values: Union[Tuple[float, float], ScalarFieldSample]) -> None:
+        if self._peak_collection is None:
+            raise RuntimeError('PeakCollection has not been set')
+
         if isinstance(values, ScalarFieldSample):
             # TODO the PeakCollection needs to be explored to determine a mapping of positions
             # to indices then set the d_reference with an ndarray
@@ -1219,15 +1230,7 @@ class StrainFieldSingle(_StrainField):
             self._peak_collection.set_d_reference(values[0], values[1])
 
     def get_d_reference(self) -> ScalarFieldSample:
-        if self._peak_collection is None:
-            raise RuntimeError('PeakCollection has not been set')
-
-        values, errors = self._peak_collection.get_d_reference()
-        full_values = np.full(len(self.point_list), NOT_MEASURED_NUMPY, dtype=float)
-        full_errors = np.full(len(self.point_list), NOT_MEASURED_NUMPY, dtype=float)
-        full_values[:values.size] = values
-        full_errors[:errors.size] = errors
-        return ScalarFieldSample('d-reference', full_values, full_errors, self.x, self.y, self.z)
+        return self._create_scalar_field(method='get_d_reference', name='d-reference')
 
 
 def _to_pointlist_and_peaks(filename: str,
@@ -1453,6 +1456,41 @@ class StrainField(_StrainField):
                                                  peak_collection=self._strains[0].peak_collections[0],
                                                  point_list=self.point_list)
 
+    def _create_scalar_field(self, method, name):
+        # make sure there is enough information to create the field
+        if not self._winners:
+            raise RuntimeError('List of winners has not been initialized')
+        if not self.point_list:
+            raise RuntimeError('The PointList has not been initialized')
+
+        num_values = len(self)  # number of sample points in the point list
+        values = np.full(num_values, NOT_MEASURED_NUMPY, dtype=float)
+        errors = np.full(num_values, NOT_MEASURED_NUMPY, dtype=float)
+
+        # loop over the winning strain indices
+        # `strain_index` identifies one of the StrainFieldSingle instances in the list self._strains
+        for strain_index in set(self._winners.scan_indexes):
+            # Find out which sample points of the aggregate point list are associated to the
+            # StrainFieldSingle object specified by `strain_index`
+            # `indices` below denote indices along the aggregated point list `self._point_list`
+            indices = np.where(self._winners.scan_indexes == strain_index)
+            # get handle to the strain and uncertainties of the StrainFieldSingle object
+            strain_field_single = self._strains[strain_index]
+
+            # get the values to put together
+            values_i, errors_i = getattr(strain_field_single.peak_collections[0], f'{method}')()
+
+            # find points of the current single-scan strain's list contributing to the overall list of points
+            # `self._winners.point_indexes` is a list as long as `self._point_list`. Each entry provides
+            # an index, specifying one sample point from one of the StrainFieldSingle components. Here
+            # we are finding out the sample points of the StrainFieldSingle object specified by
+            # `strain_index` contributing to the overall StrainField object
+            idx = self._winners.point_indexes[indices]
+            assert np.all(idx < len(strain_field_single.peak_collection))
+            values[indices], errors[indices] = values_i[idx], errors_i[idx]
+
+        return ScalarFieldSample(name, values, errors, self.x, self.y, self.z)
+
     @property
     def field(self):
         r"""
@@ -1472,37 +1510,8 @@ class StrainField(_StrainField):
 
         if len(self._strains) == 1:
             return self._strains[0].field
-        else:  # this strains is the union of two or more StrainFieldSingle objects
-            # make sure there is enough information to create the field
-            if not self._winners:
-                raise RuntimeError('List of winners has not been initialized')
-            if not self.point_list:
-                raise RuntimeError('The PointList has not been initialized')
-
-            num_values = len(self)  # number of sample points in the point list
-            values = np.full(num_values, NOT_MEASURED_NUMPY, dtype=float)
-            errors = np.full(num_values, NOT_MEASURED_NUMPY, dtype=float)
-
-            # loop over the winning strain indices
-            # `strain_index` identifies one of the StrainFieldSingle instances in the list self._strains
-            for strain_index in set(self._winners.scan_indexes):
-                # Find out which sample points of the aggregate point list are associated to the
-                # StrainFieldSingle object specified by `strain_index`
-                # `indices` below denote indices along the aggregated point list `self._point_list`
-                indices = np.where(self._winners.scan_indexes == strain_index)
-                # get handle to the strain and uncertainties of the StrainFieldSingle object
-                strain_field_single = self._strains[strain_index]
-                strain_i, error_i = strain_field_single.peak_collections[0].get_strain()
-                # find points of the current single-scan strain's list contributing to the overall list of points
-                # `self._winners.point_indexes` is a list as long as `self._point_list`. Each entry provides
-                # an index, specifying one sample point from one of the StrainFieldSingle components. Here
-                # we are finding out the sample points of the StrainFieldSingle object specified by
-                # `strain_index` contributing to the overall StrainField object
-                idx = self._winners.point_indexes[indices]
-                assert np.all(idx < len(strain_field_single.peak_collection))
-                values[indices], errors[indices] = strain_i[idx], error_i[idx]
-
-            return ScalarFieldSample('strain', values, errors, self.x, self.y, self.z)
+        else:
+            return self._create_scalar_field(method='get_strain', name='strain')
 
     @property
     def peak_collections(self) -> List[PeakCollection]:
@@ -1544,37 +1553,8 @@ class StrainField(_StrainField):
 
         if len(self._strains) == 1:
             return self._strains[0].get_d_reference()
-        else:  # this strains is the union of two or more StrainFieldSingle objects
-            # make sure there is enough information to create the field
-            if not self._winners:
-                raise RuntimeError('List of winners has not been initialized')
-            if not self.point_list:
-                raise RuntimeError('The PointList has not been initialized')
-
-            num_values = len(self)  # number of sample points in the point list
-            values = np.full(num_values, NOT_MEASURED_NUMPY, dtype=float)
-            errors = np.full(num_values, NOT_MEASURED_NUMPY, dtype=float)
-
-            # loop over the winning strain indices
-            # `strain_index` identifies one of the StrainFieldSingle instances in the list self._strains
-            for strain_index in set(self._winners.scan_indexes):
-                # Find out which sample points of the aggregate point list are associated to the
-                # StrainFieldSingle object specified by `strain_index`
-                # `indices` below denote indices along the aggregated point list `self._point_list`
-                indices = np.where(self._winners.scan_indexes == strain_index)
-                # get handle to the strain and uncertainties of the StrainFieldSingle object
-                strain_field_single = self._strains[strain_index]
-                value_i, error_i = strain_field_single.peak_collections[0].get_d_reference()
-                # find points of the current single-scan strain's list contributing to the overall list of points
-                # `self._winners.point_indexes` is a list as long as `self._point_list`. Each entry provides
-                # an index, specifying one sample point from one of the StrainFieldSingle components. Here
-                # we are finding out the sample points of the StrainFieldSingle object specified by
-                # `strain_index` contributing to the overall StrainField object
-                idx = self._winners.point_indexes[indices]
-                assert np.all(idx < len(strain_field_single.peak_collection))
-                values[indices], errors[indices] = value_i[idx], error_i[idx]
-
-            return ScalarFieldSample('d-reference', values, errors, self.x, self.y, self.z)
+        else:
+            return self._create_scalar_field(method='get_d_reference', name='d-reference')
 
 
 def generateParameterField(parameter: str,

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -694,6 +694,12 @@ class _StrainField:
     def z(self):
         return self.point_list.vz
 
+    def set_d_reference(self, values: Union[Tuple[float, float], ScalarFieldSample]) -> None:
+        raise NotImplementedError()
+
+    def get_d_reference(self) -> ScalarFieldSample:
+        raise NotImplementedError()
+
     @final
     def to_md_histo_workspace(self, name: str = '',
                               interpolate: bool = True,
@@ -1204,6 +1210,14 @@ class StrainFieldSingle(_StrainField):
         full_errors[:errors.size] = errors
         return ScalarFieldSample('strain', full_values, full_errors, self.x, self.y, self.z)
 
+    def set_d_reference(self, values: Union[Tuple[float, float], ScalarFieldSample]) -> None:
+        raise NotImplementedError()
+
+    def get_d_reference(self) -> ScalarFieldSample:
+        if self._peak_collection is None:
+            raise RuntimeError('PeakCollection has not been set')
+        raise NotImplementedError()
+
 
 def _to_pointlist_and_peaks(filename: str,
                             peak_tag: str,
@@ -1500,6 +1514,15 @@ class StrainField(_StrainField):
     @property
     def point_list(self):
         return self._point_list
+
+    def set_d_reference(self, values: Union[Tuple[float, float], ScalarFieldSample]) -> None:
+        raise NotImplementedError()
+
+    def get_d_reference(self) -> ScalarFieldSample:
+        if len(self._strains) == 1:
+            return self._strains[0].get_d_reference()
+        else:
+            raise NotImplementedError()
 
 
 def generateParameterField(parameter: str,

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -552,6 +552,26 @@ class TestStrainFieldSingle:
         assert 'sample points are overlapping' in str(exception_info.value)
 
 
+    def test_d_reference(self):
+        x = np.array([0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5])
+        y = np.array([1.0, 1.0, 1.5, 1.5, 1.0, 1.0, 1.5, 1.5])
+        z = np.array([2.0, 2.0, 2.0, 2.0, 2.5, 2.5, 2.5, 2.5])
+        point_list = PointList([x, y, z])
+        values = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+        errors = np.full(len(values), 1., dtype=float)
+        strain = StrainField(peak_collection=PeakCollectionLite('strain',
+                                                                strain=values, strain_error=errors),
+                             point_list=point_list)
+
+        D_REFERENCE = np.pi
+        D_REFERENCE_ERROR = 42
+        strain.set_d_reference((D_REFERENCE, D_REFERENCE_ERROR))
+
+        d_reference = strain.get_d_reference()
+        assert d_reference.point_list == point_list
+        np.testing.assert_equal(d_reference.values, D_REFERENCE)
+        np.testing.assert_equal(d_reference.errors, D_REFERENCE_ERROR)
+
 class Test_StrainField:
 
     class StrainFieldMock(StrainField):

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -551,7 +551,6 @@ class TestStrainFieldSingle:
             StrainField(peak_collection=peak_collection, point_list=PointList([x, y, z]))
         assert 'sample points are overlapping' in str(exception_info.value)
 
-
     def test_d_reference(self):
         x = np.array([0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5])
         y = np.array([1.0, 1.0, 1.5, 1.5, 1.0, 1.0, 1.5, 1.5])
@@ -571,6 +570,7 @@ class TestStrainFieldSingle:
         assert d_reference.point_list == point_list
         np.testing.assert_equal(d_reference.values, D_REFERENCE)
         np.testing.assert_equal(d_reference.errors, D_REFERENCE_ERROR)
+
 
 class Test_StrainField:
 
@@ -759,6 +759,41 @@ class TestStrainField:
             assert strain.peak_collections == [s.peak_collections[0] for s in (strain1, strain2, strain3)]
             values = np.concatenate((strain1.values, strain3.values))  # no strain2 because it's the same as strain1
             assert_allclose_with_sorting(strain.values, values)
+
+    def test_d_reference(self):
+        # create two strains
+        x = np.array([0.0, 0.5, 0.0, 0.5])
+        y = np.array([1.0, 1.0, 1.5, 1.5])
+        z = np.array([2.0, 2.0, 2.0, 2.0])
+        point_list = PointList([x, y, z])
+        values = np.array([1.0, 2.0, 3.0, 4.0])
+        errors = np.full(len(values), 1., dtype=float)
+        strain1 = StrainField(peak_collection=PeakCollectionLite('strain',
+                                                                 strain=values, strain_error=errors),
+                              point_list=point_list)
+
+        x = np.array([0.0, 0.5, 0.0, 0.5])
+        y = np.array([1.0, 1.0, 1.5, 1.5])
+        z = np.array([2.5, 2.5, 2.5, 2.5])
+        point_list = PointList([x, y, z])
+        values = np.array([5.0, 6.0, 7.0, 8.0])
+        errors = np.full(len(values), 1., dtype=float)
+        strain2 = StrainField(peak_collection=PeakCollectionLite('strain',
+                                                                 strain=values, strain_error=errors),
+                              point_list=point_list)
+
+        # fuse them together to get a StrainField with multiple peakcollections
+        strain = strain1.fuse_with(strain2)
+        del strain1
+        del strain2
+
+        D_REFERENCE = np.pi
+        D_REFERENCE_ERROR = 42
+        strain.set_d_reference((D_REFERENCE, D_REFERENCE_ERROR))
+
+        d_reference = strain.get_d_reference()
+        np.testing.assert_equal(d_reference.values, D_REFERENCE)
+        np.testing.assert_equal(d_reference.errors, D_REFERENCE_ERROR)
 
     def test_stack_strains(self, strain_field_samples, allclose_with_sorting):
         strain1 = strain_field_samples['HB2B_1320_peak0']


### PR DESCRIPTION
Add the ability to get/set the d-reference through the `StrainField`. Setting from a ScalarFieldSample is covered later by #664.

Refs #525 