### PR TITLE
StrainField set d-reference from ScalarFieldSample

### DIFF
--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -1163,11 +1163,13 @@ class StrainFieldSingle(_StrainField):
         if isinstance(values, ScalarFieldSample):
             # Find sample points in the point list associated to the peak collection
             assert self._point_list_immutable is not None
-            indices = self._point_list_immutable.get_indices(values.point_list)
             d_reference = self.get_d_reference()
-            values_new, errors_new = d_reference.values, d_reference.errors
-            values_new[indices] = values.values
-            errors_new[indices] = values.errors
+            values_new, errors_new = d_reference.values, d_reference.errors  # initialize new reference spacings
+            for self_index, values_index in enumerate(self._point_list_immutable.get_indices(values.point_list)):
+                if values_index == PointList.MISSING_INDEX:
+                    continue  # sample point corresponding to `self_index` is not found in `values`
+                values_new[self_index] = values.values[values_index]
+                errors_new[self_index] = values.errors[values_index]
             self._peak_collection.set_d_reference(values_new, errors_new)
         else:
             self._peak_collection.set_d_reference(values[0], values[1])

--- a/pyrs/dataobjects/sample_logs.py
+++ b/pyrs/dataobjects/sample_logs.py
@@ -1171,9 +1171,17 @@ class PointList:
 
     def get_indices(self, other: 'PointList',
                     resolution: float = DEFAULT_POINT_RESOLUTION) -> np.ndarray:
-        """return an array that is parallel to the input for indices into self of the
+        """
+        Return an array that is parallel to the input for indices into self of the
         supplied other. Any position that isn't found should be filled
-        with MISSING_INDEX (-1)."""
+        with MISSING_INDEX (-1).
+
+        Examples using unidimensional point lists:
+        If list1.vx == [1.0, 2.0, 3.0, 4.0. 5.0] and list2.vx = [4.0, 3.0], then
+        list2.get_indices(list1) == [3, 2]
+        If list1.vx == [1.0, 2.0, 3.0, 4.0. 5.0] and list2.vx = [6.0, 7.0], then
+        list2.get_indices(list1) == [-1, -1]
+        """
         if self == other:
             return np.arange(len(self))
         elif self.is_equal_within_resolution(other, resolution):
@@ -1186,7 +1194,7 @@ class PointList:
             indices = np.full(len(full_indices), self.MISSING_INDEX, dtype=int)
             for i, index in enumerate(full_indices):
                 indices[i] = index[1]
-            return indices[:len(other)]
+            return indices[:len(self)]
 
     def extents(self, resolution=DEFAULT_POINT_RESOLUTION) -> ExtentTriad:
         r"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,35 +147,6 @@ def strain_single_builder():
     return wrapped_function
 
 
-@pytest.fixture(scope='session')
-def strain_builder(strain_single_builder):
-
-    def wrapped_function(peaks_data):
-        r"""
-        Constructor of `StrainField` objects
-
-        Parameters
-        ----------
-        peaks_data: dict
-
-        Returns
-        -------
-        ~pyrs.dataobjects.fields.StrainField
-
-        Examples
-        --------
-
-        """
-        strain_single = strain_single_builder(peaks_data)
-        strain = StrainField()
-        strain._strains.append(strain_single)
-        strain._point_list = strain_single.point_list
-
-        return strain
-
-    return wrapped_function
-
-
 @pytest.fixture(scope='function')
 def strain_single_object_0(strain_single_builder):
     r"""Serves a StrainFieldSingle object"""
@@ -207,6 +178,175 @@ def strain_single_object_0(strain_single_builder):
 
     # create a StrainField object
     return strain_single_builder(scan)
+
+
+@pytest.fixture(scope='session')
+def strain_builder(strain_single_builder):
+
+    def wrapped_function(peaks_data):
+        r"""
+        Constructor of `StrainField` objects
+
+        Parameters
+        ----------
+        peaks_data: dict
+
+        Returns
+        -------
+        ~pyrs.dataobjects.fields.StrainField
+
+        Examples
+        --------
+
+        """
+        strain_single = strain_single_builder(peaks_data)
+        strain = StrainField()
+        strain._strains.append(strain_single)
+        strain._point_list = strain_single.point_list
+
+        return strain
+
+    return wrapped_function
+
+
+@pytest.fixture(scope='function')
+def strain_object_0(strain_builder):
+    r"""Serves a StrainField object made up of one StrainFieldSingle object"""
+    scan = {
+        'runnumber': '1234',
+        'subruns': [1, 2, 3, 4, 5, 6, 7, 8],
+        'peak_tag': 'test',
+        'wavelength': 2.0,
+        'd_reference': 1.0,
+        'peak_profile': 'pseudovoigt',
+        'background_type': 'linear',
+        # parameters appropriate to the selected peak shape, except for parameter PeakCentre
+        'native': {
+            'Intensity': [100, 110, 120, 130, 140, 150, 160, 170],
+            'FWHM': [1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7],
+            'Mixing': [1.0] * 8,
+            'A0': [10., 11., 12., 13., 14., 15., 16., 17.],
+            'A1': [0.00, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07],
+        },
+        'fit_costs': [1.0] * 8,
+        # will back-calculate PeakCentre values in order to end up with these lattice spacings
+        'd_spacing': [1.00, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07],
+        # errors in native parameters are taken to be their values times this error fraction
+        'error_fraction': 0.1,
+        'vx': [0., 1., 2., 3., 4., 5., 6., 7.],
+        'vy': [0.] * 8,
+        'vz': [0.] * 8
+    }
+
+    # create a StrainField object
+    return strain_builder(scan)
+
+
+@pytest.fixture(scope='function')
+def strain_object_1(strain_builder):
+    r"""Serves a StrainField object made up of two non-overlapping StrainFieldSingle objects"""
+    common_data = {
+        'peak_tag': 'test',
+        'wavelength': 2.0,
+        'd_reference': 1.0,
+        'peak_profile': 'pseudovoigt',
+        'background_type': 'linear',
+        # errors in native parameters are taken to be their values times this error fraction
+        'error_fraction': 0.1,
+    }
+
+    strain_1235_data = deepcopy(common_data)
+    strain_1235_data.update({
+        'runnumber': '1235',
+        'subruns': [1, 2, 3, 4],
+        'native': {
+            'Intensity': [110, 120, 130, 140],
+            'FWHM': [1.1, 1.2, 1.3, 1.4],
+            'Mixing': [1.0] * 4,
+            'A0': [11., 12., 13., 14.],
+            'A1': [0.01, 0.02, 0.03, 0.04],
+        },
+        'fit_costs': [1.0] * 4,
+        'd_spacing': [1.01, 1.02, 1.03, 1.04],  # notice the last value
+        'vx': [1., 2., 3., 4.],
+        'vy': [0.] * 4,
+        'vz': [0.] * 4
+    })
+    strain_1235 = strain_builder(strain_1235_data)
+
+    strain_1236_data = deepcopy(common_data)
+    strain_1236_data.update({
+        'runnumber': '1236',
+        'subruns': [1, 2, 3, 4],
+        'native': {
+            'Intensity': [150, 160, 170, 180],
+            'FWHM': [1.5, 1.6, 1.7, 1.8],
+            'Mixing': [1.0] * 4,
+            'A0': [15., 16., 17., 18.],
+            'A1': [0.05, 0.06, 0.07, 0.08],
+        },
+        'fit_costs': [1.0] * 4,
+        'd_spacing': [1.05, 1.06, 1.07, 1.08],  # notice the first value
+        'vx': [5., 6., 7., 8.],
+        'vy': [0.] * 4,
+        'vz': [0.] * 4
+    })
+    strain_1236 = strain_builder(strain_1236_data)
+
+    return strain_1235 + strain_1236
+
+
+@pytest.fixture(scope='function')
+def strain_object_2(strain_builder):
+    r"""Serves a StrainField object made up of two overlapping StrainFieldSingle objects"""
+    common_data = {
+        'peak_tag': 'test',
+        'wavelength': 2.0,
+        'd_reference': 1.0,
+        'peak_profile': 'pseudovoigt',
+        'background_type': 'linear',
+        # errors in native parameters are taken to be their values times this error fraction
+        'error_fraction': 0.1,
+    }
+    strain_1235_data = deepcopy(common_data)
+    strain_1235_data.update({
+        'runnumber': '1235',
+        'subruns': [1, 2, 3, 4],
+        'native': {
+            'Intensity': [110, 120, 130, 140],
+            'FWHM': [1.1, 1.2, 1.3, 1.4],
+            'Mixing': [1.0] * 4,
+            'A0': [11., 12., 13., 14.],
+            'A1': [0.01, 0.02, 0.03, 0.04],
+        },
+        'fit_costs': [1.0] * 4,
+        'd_spacing': [1.01, 1.02, 1.03, 1.04],  # notice the last value
+        'vx': [1., 2., 3., 4.],
+        'vy': [0.] * 4,
+        'vz': [0.] * 4
+    })
+    strain_1235 = strain_builder(strain_1235_data)
+
+    strain_1236_data = deepcopy(common_data)
+    strain_1236_data.update({
+        'runnumber': '1236',
+        'subruns': [1, 2, 3, 4, 5],
+        'native': {
+            'Intensity': [140, 150, 160, 170, 180],
+            'FWHM': [1.4, 1.5, 1.6, 1.7, 1.8],
+            'Mixing': [1.0] * 5,
+            'A0': [14., 15., 16., 17., 18.],
+            'A1': [0.04, 0.05, 0.06, 0.07, 0.08],
+        },
+        'fit_costs': [1.0] * 5,
+        'd_spacing': [1.045, 1.05, 1.06, 1.07, 1.08],  # notice the first value
+        'vx': [4., 5., 6., 7., 8.],
+        'vy': [0.] * 5,
+        'vz': [0.] * 5
+    })
+    strain_1236 = strain_builder(strain_1236_data)
+
+    return strain_1235 + strain_1236
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
-from pyrs.dataobjects.fields import StrainFieldSingle
+from pyrs.dataobjects.fields import StrainField, StrainFieldSingle
 
 
 def test_strain_single_builder(strain_single_builder):
@@ -90,6 +90,22 @@ def test_strain_single_object_0(strain_single_object_0):
     assert isinstance(strain_single_object_0, StrainFieldSingle)
     expected = [0.00, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07]
     assert_allclose(strain_single_object_0.values, expected, rtol=1.e-07, atol=1.e-07)
+
+
+def test_strain_object_0(strain_object_0):
+    assert isinstance(strain_object_0, StrainField)
+    expected = [0.00, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07]
+    assert_allclose(strain_object_0.values, expected, rtol=1.e-07, atol=1.e-07)
+
+
+def test_strain_object_1(strain_object_1):
+    assert isinstance(strain_object_1, StrainField)
+    assert_allclose(strain_object_1.values, np.arange(0.01, 0.085, 0.01), rtol=1.e-07, atol=1.e-07)
+
+
+def test_strain_object_2(strain_object_2):
+    assert isinstance(strain_object_2, StrainField)
+    assert_allclose(strain_object_2.values, np.arange(0.01, 0.085, 0.01), rtol=1.e-07, atol=1.e-07)
 
 
 def test_strain_stress_object_0(strain_stress_object_0):

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,6 +1,49 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
+from pyrs.dataobjects.fields import StrainFieldSingle
+
+
+def test_strain_single_builder(strain_single_builder):
+    # all input data
+    scan = {
+        'runnumber': '1234',
+        'subruns': [1, 2, 3, 4, 5, 6, 7, 8],
+        'peak_tag': 'test',
+        'wavelength': 2.0,
+        'd_reference': 1.0,
+        'peak_profile': 'pseudovoigt',
+        'background_type': 'linear',
+        # parameters appropriate to the selected peak shape, except for parameter PeakCentre
+        'native': {
+            'Intensity': [100, 110, 120, 130, 140, 150, 160, 170],
+            'FWHM': [1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7],
+            'Mixing': [1.0] * 8,
+            'A0': [10., 11., 12., 13., 14., 15., 16., 17.],
+            'A1': [0.00, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07],
+        },
+        'fit_costs': [1.0] * 8,
+        # will back-calculate PeakCentre values in order to end up with these lattice spacings
+        'd_spacing': [1.00, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07],
+        # errors in native parameters are taken to be their values times this error fraction
+        'error_fraction': 0.1,
+        'vx': [0., 1., 2., 3., 4., 5., 6., 7.],
+        'vy': [0.] * 8,
+        'vz': [0.] * 8
+    }
+
+    # create a StrainField object
+    strain = strain_single_builder(scan)
+
+    # assert entered data
+    assert_allclose(strain.point_list.vx, np.array(scan['vx']))
+    assert_allclose(strain.get_d_reference().values, np.repeat(scan['d_reference'], len(scan['subruns'])))
+    assert_allclose(strain.get_dspacing_center().values, np.array(scan['d_spacing']))
+    strain_expected_values = (scan['d_spacing'] - scan['d_reference']) / scan['d_reference']
+    assert_allclose(strain.field.values, strain_expected_values, rtol=1e-07, atol=1.e-07)
+    for name in ['Intensity', 'FWHM', 'Mixing', 'A0', 'A1']:
+        assert_allclose(strain.get_effective_peak_parameter(name).values, np.array(scan['native'][name]))
+
 
 def test_strain_builder(strain_builder):
     # all input data
@@ -41,6 +84,12 @@ def test_strain_builder(strain_builder):
     assert_allclose(strain.field.values, strain_expected_values, rtol=1e-07, atol=1.e-07)
     for name in ['Intensity', 'FWHM', 'Mixing', 'A0', 'A1']:
         assert_allclose(strain.get_effective_peak_parameter(name).values, np.array(scan['native'][name]))
+
+
+def test_strain_single_object_0(strain_single_object_0):
+    assert isinstance(strain_single_object_0, StrainFieldSingle)
+    expected = [0.00, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07]
+    assert_allclose(strain_single_object_0.values, expected, rtol=1.e-07, atol=1.e-07)
 
 
 def test_strain_stress_object_0(strain_stress_object_0):

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -840,6 +840,61 @@ class TestStrainField:
         np.testing.assert_equal(d_reference.values, D_REFERENCE)
         np.testing.assert_equal(d_reference.errors, D_REFERENCE_ERROR)
 
+    def test_set_d_reference(self, strain_object_0, strain_object_1, strain_object_2,
+                             strain_stress_object_0, strain_stress_object_1):
+        r"""
+        Test using a ScalarFieldSample
+        strain_object_0: StrainField object made up of one StrainFieldSingle object
+        strain_object_1: StrainField object made up of two non-overlapping StrainFieldSingle object
+        strain_object_2: StrainField object made up of two overlapping StrainFieldSingle objects
+        strain_stress_object_0: strains stacked, all have the same set of sample points
+        """
+        for strain, expected in [(strain_object_0, [1.00, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07]),
+                                 (strain_object_1, [1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07, 1.08]),
+                                 (strain_object_2, [1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07, 1.08])]:
+            d_spacing = strain.get_dspacing_center()
+            assert_allclose(d_spacing.values, expected, atol=0.001)
+            # Set the reference spacings as the observed lattice plane spacings
+            strain.set_d_reference(d_spacing)
+            assert_allclose(strain.get_d_reference().values, expected)
+            # There should be no strain, since the observed lattice plane spacings are the reference spacings
+            assert_allclose(strain.values, np.zeros(8), atol=1.e-5)
+        #
+        # Use a new d_reference defined over a set of sample points having no overlap. In this case,
+        # the d_reference of the strains should be left untouched
+        d_reference_update = ScalarFieldSample('d_reference',
+                                               values=[9, 9, 9], errors=[0.0, 0.0, 0.0],
+                                               x=[9, 9, 9], y=[0, 0, 0], z=[0, 0, 0])
+        for strain in (strain_object_0, strain_object_1, strain_object_2):
+            d_reference_old = strain.get_d_reference()
+            strain.set_d_reference(d_reference_update)  # no effect
+            assert_allclose(strain.get_d_reference().values, d_reference_old.values)
+        #
+        # Use a new d_reference defined over a set of sample points corresponding to the last
+        # three points of the strain field
+        for strain in (strain_object_0,):
+            d_reference_update = ScalarFieldSample('d_reference',
+                                                   values=[9, 9, 9], errors=[0.0, 0.0, 0.0],
+                                                   x=strain.x[-3:], y=strain.y[-3:], z=strain.z[-3:])
+            d_reference_old = strain.get_d_reference()
+            strain.set_d_reference(d_reference_update)  # affects only the last three points
+            assert_allclose(strain.get_d_reference().values[: -3], d_reference_old.values[: -3])
+            assert_allclose(strain.get_d_reference().values[-3:], [9, 9, 9])
+
+        #
+        # Use a new d_reference defined over a set of sample points corresponding to the last
+        # three points of the stacked strains in strain_stress_object_0
+        strains = strain_stress_object_0['strains']
+        pl = strains['11'].point_list
+        d_reference_update = ScalarFieldSample('d_reference',
+                                               values=[9, 9, 9], errors=[0.0, 0.0, 0.0],
+                                               x=pl.vx[-3:], y=pl.vy[-3:], z=pl.vz[-3:])
+        for strain in strains.values():  # `strains` is a dictionary
+            d_reference_old = strain.get_d_reference()
+            strain.set_d_reference(d_reference_update)  # affects only the last three points
+            assert_allclose(strain.get_d_reference().values[: -3], d_reference_old.values[: -3])
+            assert_allclose(strain.get_d_reference().values[-3:], [9, 9, 9])
+
     def test_stack_strains(self, strain_field_samples, allclose_with_sorting):
         strain1 = strain_field_samples['HB2B_1320_peak0']
         strain2 = strain_field_samples['HB2B_1320_']

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -619,7 +619,7 @@ class Test_StrainField:
                 assert isinstance(s, StrainFieldSingle)
             self._strains = strains
 
-    def test_eq(self, strain_field_samples, str):
+    def test_eq(self, strain_field_samples):
         strains_single_scan = copy.deepcopy(list(strain_field_samples.values()))
         # single-scan strains
         assert strains_single_scan[0] == strains_single_scan[0]

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -583,6 +583,17 @@ class TestStrainFieldSingle:
         np.testing.assert_equal(d_reference.values, D_REFERENCE)
         np.testing.assert_equal(d_reference.errors, D_REFERENCE_ERROR)
 
+    def test_set_d_reference(self, strain_single_object_0):
+        r"""Test using a ScalarFieldSample"""
+        d_spacing = strain_single_object_0.get_dspacing_center()
+        expected = [1.00, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07]
+        assert_allclose(d_spacing.values, expected, atol=0.001)
+        # Set the reference spacings as the observed lattice plane spacings
+        strain_single_object_0.set_d_reference(d_spacing)
+        assert_allclose(strain_single_object_0.get_d_reference().values, expected)
+        # There should be no strain, since the observed lattice plane spacings are the reference spacings
+        assert_allclose(strain_single_object_0.values, np.zeros(8), atol=1.e-5)
+
     def test_get_peak_params(self, strain_field_samples):
         strain = strain_field_samples['strain with two points per direction']  # mock object
 
@@ -608,7 +619,7 @@ class Test_StrainField:
                 assert isinstance(s, StrainFieldSingle)
             self._strains = strains
 
-    def test_eq(self, strain_field_samples):
+    def test_eq(self, strain_field_samples, str):
         strains_single_scan = copy.deepcopy(list(strain_field_samples.values()))
         # single-scan strains
         assert strains_single_scan[0] == strains_single_scan[0]

--- a/tests/unit/pyrs/dataobjects/test_sample_logs.py
+++ b/tests/unit/pyrs/dataobjects/test_sample_logs.py
@@ -316,9 +316,15 @@ class TestPointList:
         z = [2.5, 2.5, 2.5, 2.5, 2.0, 2.0, 2.0, 2.0]
         point_list3 = PointList([x, y, z])
 
+        # last three sample points of point_list1
+        x = [0.5, 0.0, 0.5]  # x
+        y = [1.0, 1.5, 1.5]  # y
+        z = [2.5, 2.5, 2.5]  # z
+        point_list4 = PointList([x, y, z])
+
         # indices with self are running numbers
-        for point_list in (point_list1, point_list2, point_list3):
-            np.testing.assert_equal(point_list.get_indices(point_list), np.arange(len(x)))
+        for point_list in (point_list1, point_list2, point_list3, point_list4):
+            np.testing.assert_equal(point_list.get_indices(point_list), np.arange(len(point_list)))
 
         # reversing values gets decreasing numbers
         for forward, reverse in zip((point_list1, point_list3), (point_list3, point_list1)):
@@ -327,6 +333,10 @@ class TestPointList:
         # partial matching tests
         np.testing.assert_equal(point_list1.get_indices(point_list2), [0, 1, 2, 3, -1, -1, -1, -1])
         np.testing.assert_equal(point_list3.get_indices(point_list2), [-1, -1, -1, -1, 3, 2, 1, 0])
+
+        np.testing.assert_equal(point_list4.get_indices(point_list1), [5, 6, 7])
+        np.testing.assert_equal(point_list4.get_indices(point_list2), [-1, -1, -1])
+        np.testing.assert_equal(point_list4.get_indices(point_list3), [2, 1, 0])
 
 
 def test_aggregate_point_list(sample_logs_mock):


### PR DESCRIPTION
Work done
- [x] fixtures `strain_single_builder`, `strain_single_object_0`, `strain_object_0`, `strain_object_1`
- [x] set reference spacing in StrainFieldSingle and unit test
- [x] set reference spacing in StrainField and unit tests
- [x] bugfix in `PointList.get_indices()`

Refs #664