### PR TITLE
StressField set d-reference from ScalarFieldSample

### DIFF
--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -1827,7 +1827,7 @@ class StressField:
         if self.stress_type == StressType.DIAGONAL:
             strain33: unumpy.uarray = self._strain33.sample
         else:
-            strain33 = sample_zero
+            strain33 = sample_zero  # this even for StressType.IN_PLANE_STRESS
 
         # calculate the additive trace
         f = 1.0 if self.stress_type == StressType.IN_PLANE_STRESS else 2.0
@@ -1897,8 +1897,15 @@ class StressField:
 
     def set_d_reference(self, values: Union[Tuple[float, float], ScalarFieldSample]) -> None:
         # the strains have already been stacked
-        for strain in (self._strain11, self._strain22, self._strain33):
-            strain.set_d_reference(values)
+        self._strain11.set_d_reference(values)
+        self._strain22.set_d_reference(values)
+
+        if self.stress_type == StressType.DIAGONAL:
+            self._strain33.set_d_reference(values)
+        elif self.stress_type == StressType.IN_PLANE_STRESS:
+            self._strain33 = self._strain33_when_inplane_stress()
+        else:
+            pass  # in-plane-strain is unaffected by d_reference because it's always zero
 
         self.update_stress_calculation()
 

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -1903,7 +1903,7 @@ class StressField:
         if self.stress_type == StressType.DIAGONAL:
             self._strain33.set_d_reference(values)
         elif self.stress_type == StressType.IN_PLANE_STRESS:
-            self._strain33 = self._strain33_when_inplane_stress()
+            self._strain33 = self._strain33_when_inplane_stress()  # recalculate the strain33 component
         else:
             pass  # in-plane-strain is unaffected by d_reference because it's always zero
 


### PR DESCRIPTION
Work done:
- [x] bugfix in StressField.set_d_reference
- [x] unit test for simple case, for diagonal, in-plane-strain, and in-plane-stress

Refs #683 