### PR TITLE
Check setting the reference spacing in a multi-scan with different set of points along different directions

### DIFF
--- a/pyrs/core/stress_facade.py
+++ b/pyrs/core/stress_facade.py
@@ -154,7 +154,7 @@ class StressFacade:
         d0s_values = [d0.values for d0 in d0s]
         for d0_ii in d0s_values[:-1]:
             for d0_jj in d0s_values[1:]:
-                mask = ~(np.isnan(d0_ii) | np.isnan(d0_jj))
+                mask = ~(np.isnan(d0_ii) | np.isnan(d0_jj))  # indexes where d0_ii and d0_jj are not Nan
                 assert_allclose(d0_ii[mask], d0_jj[mask], rtol=1.e-4,
                                 err_msg='reference spacings are different on different directions')
 

--- a/tests/unit/pyrs/core/test_stress_facade.py
+++ b/tests/unit/pyrs/core/test_stress_facade.py
@@ -214,13 +214,20 @@ class TestStressFacade:
         assert 'Stress can only be computed for directions' in str(exception_info.value)
         # TODO assert stresses for the remaining selections
 
-    @pytest.mark.skip(reason='Not yet implemented')
     def test_d_reference_field(self, strain_stress_object_1):
         r"""Get the reference lattice spacing"""
-        facade = StressFacade(strain_stress_object_1['stresses']['diagonal'])
-        assert_allclose(facade.d_reference, np.ones(facade.size))
+        stress = strain_stress_object_1['stresses']['diagonal']
+        facade = StressFacade(stress)
+        assert_allclose(facade.d_reference.values, np.ones(facade.size))
+        # "pollute" the reference spacing of run 1235
+        strain_single_1235 = stress.strain22.strains[0]
+        strain_single_1235.set_d_reference([1.001, 0.1])
+        facade = StressFacade(stress)
+        with pytest.raises(AssertionError) as exception_info:
+            facade.d_reference
+        assert 'reference spacings are different on different directions' in str(exception_info.value)
 
-    def test_set_d_reference(self, strain_stress_object_0):
+    def test_set_d_reference(self, strain_stress_object_0, strain_stress_object_1):
         facade = StressFacade(strain_stress_object_0['stresses']['diagonal'])
         #
         # Case single value (errors assumed 0.0)

--- a/tests/unit/pyrs/core/test_stress_facade.py
+++ b/tests/unit/pyrs/core/test_stress_facade.py
@@ -297,7 +297,7 @@ class TestStressFacade:
         assert_allclose(facade.d_reference.values, np.ones(facade.size))
         assert_allclose(facade.d_reference.errors, np.zeros(facade.size))
         indexes = [0, 2, 4, 6, 8]  # indexes of the sample points whose d_reference will be updated
-        d_update = ScalarFieldSample('d_reference', values[indexes], errors,
+        d_update = ScalarFieldSample('d_reference', values[indexes], errors[indexes],
                                      facade.x[indexes], facade.y[indexes], facade.z[indexes])
         facade.d_reference = d_update
         assert_allclose(facade.d_reference.values, [1.00, 1.00, 1.20, 1.00, 1.40, 1.00, 1.60, 1.00, 1.80, 1.00])

--- a/tests/unit/pyrs/core/test_stress_facade.py
+++ b/tests/unit/pyrs/core/test_stress_facade.py
@@ -297,7 +297,7 @@ class TestStressFacade:
         assert_allclose(facade.d_reference.values, np.ones(facade.size))
         assert_allclose(facade.d_reference.errors, np.zeros(facade.size))
         indexes = [0, 2, 4, 6, 8]  # indexes of the sample points whose d_reference will be updated
-        d_update = ScalarFieldSample('d_reference', values[indexes], 0.1 * values[indexes],
+        d_update = ScalarFieldSample('d_reference', values[indexes], errors,
                                      facade.x[indexes], facade.y[indexes], facade.z[indexes])
         facade.d_reference = d_update
         assert_allclose(facade.d_reference.values, [1.00, 1.00, 1.20, 1.00, 1.40, 1.00, 1.60, 1.00, 1.80, 1.00])


### PR DESCRIPTION
Work done:
 - [x] Test d_reference raises when overlapping points report different values

Refs #715