### PR TITLE
Include d_spacing_center as a peak parameter in the facade object

### DIFF
--- a/pyrs/core/stress_facade.py
+++ b/pyrs/core/stress_facade.py
@@ -328,6 +328,7 @@ class StressFacade:
             msg = f'd-spacing not measured along 33 when in {self.stress_type}'
             raise ValueError(msg)
 
+        assert self._selection is not None
         d_spacing_field = self._strain_cache[self._selection].get_dspacing_center()
 
         return self._extend_to_stacked_point_list(d_spacing_field)

--- a/tests/unit/pyrs/core/test_stress_facade.py
+++ b/tests/unit/pyrs/core/test_stress_facade.py
@@ -395,4 +395,4 @@ class TestStressFacade:
         facade.selection = '33'
         with pytest.raises(ValueError) as exception_info:
             facade.peak_parameter('d')
-        assert f'd-spacing not measured along 33 when in in-plane-strain' in str(exception_info.value)
+        assert 'd-spacing not measured along 33 when in in-plane-strain' in str(exception_info.value)

--- a/tests/unit/pyrs/core/test_stress_facade.py
+++ b/tests/unit/pyrs/core/test_stress_facade.py
@@ -363,7 +363,7 @@ class TestStressFacade:
         facade.selection = '11'
         with pytest.raises(ValueError) as exception_info:
             facade.workspace('Center')
-        assert 'Peak parameters can only be retrieved for run numbers' in str(exception_info.value)
+        assert 'Peak parameter Center can only be retrieved for run numbers' in str(exception_info.value)
         facade.selection = '1234'
         with pytest.raises(AssertionError) as exception_info:
             facade.workspace('center')


### PR DESCRIPTION
Work done:
- [x] property `StressFacade.stress_type` and unit test
- [x] protected `StressFacade._d_spacing()` find the d-spacing for a direction or single run
- [x] public `StressFacade.peak_parameter()` accepts 'd' as parameter, and unit test

Refs #719