### PR TITLE
Facade object should provide peak parameters along directions

### DIFF
--- a/pyrs/core/stress_facade.py
+++ b/pyrs/core/stress_facade.py
@@ -308,10 +308,6 @@ class StressFacade:
         if query == 'd':
             return self._d_spacing()
 
-        if self._selection in ('11', '22', '33'):
-            msg = f'Peak parameter {query} can only be retrieved for run numbers, not directions.'
-            raise ValueError(msg)
-
         peak_parameter_field = self._strain_cache[self._selection].get_effective_peak_parameter(query)
 
         return self._extend_to_stacked_point_list(peak_parameter_field)

--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -1671,15 +1671,10 @@ class StrainField(_StrainField):
     def get_effective_peak_parameter(self, name: str) -> ScalarFieldSample:
         self._validate_peak_param_name(name)
 
-        if len(self._strains) == 1:
-            # delegate the work to the only StrainField
-            return self._strains[0].get_effective_peak_parameter(name)
-        else:
-            # look for it in the cache
-            if name not in self._effective_params.keys():
-                self._effective_params[name] = self._create_scalar_field(method=name, name=name)
+        if name not in self._effective_params.keys():  # look for it in the cache
+            self._effective_params[name] = self._create_scalar_field(method=name, name=name)
 
-            return self._effective_params[name]
+        return self._effective_params[name]
 
 
 def aggregate_scalar_field_samples(*args) -> 'ScalarFieldSample':

--- a/tests/plot_sample_points.py
+++ b/tests/plot_sample_points.py
@@ -1,0 +1,27 @@
+from mpl_toolkits.mplot3d import Axes3D
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+from pyrs.dataobjects.fields import StrainField
+
+test_data_dir = '/home/jbq/repositories/pyrs/pyrs1/tests/data'
+
+
+def plot_sample_points(*files):
+
+    strain22 = StrainField(filename=os.path.join(test_data_dir, files[1]),
+                           peak_tag='peak0')
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+
+    for file in files:
+        strain = StrainField(filename=os.path.join(test_data_dir, file), peak_tag='peak0')
+        ax.scatter(strain.x, strain.y, strain.z)
+
+    ax.set_xlabel('X Label')
+    ax.set_ylabel('Y Label')
+    ax.set_zlabel('Z Label')
+    plt.legend(files)
+    plt.show()
+
+plot_sample_points('HB2B_1327.h5', 'HB2B_1328.h5', 'HB2B_1331.h5', 'HB2B_1332.h5')

--- a/tests/plot_sample_points.py
+++ b/tests/plot_sample_points.py
@@ -1,6 +1,5 @@
-from mpl_toolkits.mplot3d import Axes3D
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
 import matplotlib.pyplot as plt
-import numpy as np
 import os
 from pyrs.dataobjects.fields import StrainField
 
@@ -9,8 +8,6 @@ test_data_dir = '/home/jbq/repositories/pyrs/pyrs1/tests/data'
 
 def plot_sample_points(*files):
 
-    strain22 = StrainField(filename=os.path.join(test_data_dir, files[1]),
-                           peak_tag='peak0')
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
 
@@ -23,5 +20,6 @@ def plot_sample_points(*files):
     ax.set_zlabel('Z Label')
     plt.legend(files)
     plt.show()
+
 
 plot_sample_points('HB2B_1327.h5', 'HB2B_1328.h5', 'HB2B_1331.h5', 'HB2B_1332.h5')

--- a/tests/unit/pyrs/core/test_stress_facade.py
+++ b/tests/unit/pyrs/core/test_stress_facade.py
@@ -336,10 +336,10 @@ class TestStressFacade:
     def test_peak_parameter_field(self, strain_stress_object_1):
         r"""Retrieve the effective peak parameters for a particular run, or for a particular direction"""
         facade = StressFacade(strain_stress_object_1['stresses']['diagonal'])
+
         facade.selection = '11'
-        with pytest.raises(ValueError) as exception_info:
-            facade.peak_parameter('Center')
-        assert 'Peak parameter Center can only be retrieved for run numbers' in str(exception_info.value)
+        expected = [100, 110, 120, 130, 140, 150, 160, 170, nanf, nanf]
+        assert_allclose(facade.peak_parameter('Intensity').values, expected, equal_nan=True)
         facade.selection = '1234'
         with pytest.raises(AssertionError) as exception_info:
             facade.peak_parameter('center')
@@ -347,12 +347,20 @@ class TestStressFacade:
         facade.selection = '1234'
         expected = [100, 110, 120, 130, 140, 150, 160, 170, nanf, nanf]
         assert_allclose(facade.peak_parameter('Intensity').values, expected, equal_nan=True)
+
+        facade.selection = '22'
+        expected = [nanf, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, nanf]
+        assert_allclose(facade.peak_parameter('FWHM').values, expected, equal_nan=True)
         facade.selection = '1235'
         expected = [nanf, 1.1, 1.2, 1.3, 1.4, nanf, nanf, nanf, nanf, nanf]
         assert_allclose(facade.peak_parameter('FWHM').values, expected, equal_nan=True)
         facade.selection = '1236'
         expected = [nanf, nanf, nanf, nanf, 14., 15., 16., 17., 18., nanf]
         assert_allclose(facade.peak_parameter('A0').values, expected, equal_nan=True)
+
+        facade.selection = '33'
+        expected = [nanf, nanf, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09]
+        assert_allclose(facade.peak_parameter('A1').values, expected, equal_nan=True)
         facade.selection = '1237'
         expected = [nanf, nanf, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09]
         assert_allclose(facade.peak_parameter('A1').values, expected, equal_nan=True)
@@ -360,10 +368,6 @@ class TestStressFacade:
     def test_peak_parameter_workspace(self, strain_stress_object_1):
         r"""Retrieve the effective peak parameters for a particular run, or for a particular direction"""
         facade = StressFacade(strain_stress_object_1['stresses']['diagonal'])
-        facade.selection = '11'
-        with pytest.raises(ValueError) as exception_info:
-            facade.workspace('Center')
-        assert 'Peak parameter Center can only be retrieved for run numbers' in str(exception_info.value)
         facade.selection = '1234'
         with pytest.raises(AssertionError) as exception_info:
             facade.workspace('center')


### PR DESCRIPTION
Work done:
- [x] enable reporting peak parameters along directions, not just single runs

Refs #721