### PR TITLE
StressFacade.peak_parameter should raise when selecting 33 in a surface scan

### DIFF
--- a/pyrs/core/stress_facade.py
+++ b/pyrs/core/stress_facade.py
@@ -308,6 +308,10 @@ class StressFacade:
         if query == 'd':
             return self._d_spacing()
 
+        if self._selection == '33' and self.stress_type in ('in-plane-strain', 'in-plane-stress'):
+            msg = f'{query} not measured along 33 when in {self.stress_type}'
+            raise ValueError(msg)
+
         peak_parameter_field = self._strain_cache[self._selection].get_effective_peak_parameter(query)
 
         return self._extend_to_stacked_point_list(peak_parameter_field)

--- a/tests/unit/pyrs/core/test_stress_facade.py
+++ b/tests/unit/pyrs/core/test_stress_facade.py
@@ -443,6 +443,18 @@ class TestStressFacade:
         expected = [nanf, nanf, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09]
         assert_allclose(facade.peak_parameter('A1').values, expected, equal_nan=True)
 
+        facade = StressFacade(strain_stress_object_1['stresses']['in-plane-strain'])
+        facade.selection = '33'
+        with pytest.raises(ValueError) as exception_info:
+            facade.peak_parameter('Intensity')
+        assert 'Intensity not measured along 33 when in in-plane-strain'
+
+        facade = StressFacade(strain_stress_object_1['stresses']['in-plane-stress'])
+        facade.selection = '33'
+        with pytest.raises(ValueError) as exception_info:
+            facade.peak_parameter('FWHM')
+        assert 'FWHM not measured along 33 when in in-plane-stress'
+
     def test_peak_parameter_workspace(self, strain_stress_object_1):
         r"""Retrieve the effective peak parameters for a particular run, or for a particular direction"""
         facade = StressFacade(strain_stress_object_1['stresses']['diagonal'])


### PR DESCRIPTION
Work done:
- [x] include an exception in `StressFacade.peak_parameter` that raises when selection is `33` and the stress type is `in-plane-strain` or `in-plane-stress`
- [x] testing the exception is raised when `in-plane-strain` or `in-plane-stress`

Refs #725