### PR TITLE
StrainField should return field in units of microstrain

### DIFF
--- a/pyrs/dataobjects/fields.py
+++ b/pyrs/dataobjects/fields.py
@@ -1784,6 +1784,27 @@ class Direction(Enum):
 
 
 class StressField:
+
+    @staticmethod
+    def to_megapascal(stress_values):
+        r"""
+        Convert from GPa * microstrain to MPa, which amounts to a factor of 1.e-3
+
+        Parameters
+        ----------
+        stress_values: np.ndarray, tuple, list
+            stress values to be converted from (GPa * microstrain) to MPa units
+        Returns
+        -------
+        np.ndarray, list
+            numpy array if `stress` is also a numpy array, otherwise a list
+        """
+        conversion_factor = 1.0e-03
+        if isinstance(stress_values, np.ndarray):
+            return conversion_factor * stress_values
+        else:
+            return [conversion_factor * s for s in stress_values]
+
     r"""
     Calculate the three diagonal components of the stress tensor, assuming a diagonal strain tensor.
 
@@ -2025,8 +2046,8 @@ class StressField:
         """
         factor = self.poisson_ratio / (self.poisson_ratio - 1)
         strain33 = factor * (self._strain11.sample + self._strain22.sample)  # unumpy.array
-        values, errors = unumpy.nominal_values(strain33), unumpy.std_devs(strain33)
-        peaks = PeakCollectionLite(str(StressType.IN_PLANE_STRESS), values, errors)
+        values, errors = unumpy.nominal_values(strain33), unumpy.std_devs(strain33)  # units are microstrain
+        peaks = PeakCollectionLite(str(StressType.IN_PLANE_STRESS), values, errors, strain_units='microstrain')
         return StrainField(peak_collection=peaks, point_list=PointList([self.x, self.y, self.z]))  # type: ignore
 
     def set_d_reference(self, values: Union[Tuple[float, float], ScalarFieldSample]) -> None:

--- a/pyrs/peaks/peak_collection.py
+++ b/pyrs/peaks/peak_collection.py
@@ -32,6 +32,25 @@ def get_strain_conversion_factor(units: str = 'strain') -> float:
     return conversion_factor
 
 
+def to_microstrain(strains):
+    r"""
+    convert a list of strains from strain to microstrains units
+
+    Parameters
+    ----------
+    strains: np.ndarray, tuple, list
+
+    Returns
+    -------
+    np.ndarray, list
+        numpy array if `strains` is also a numpy array, otherwise return a list
+    """
+    microstrain = get_strain_conversion_factor(units='microstrain')
+    if isinstance(strains, np.ndarray):
+        return microstrain * strains
+    return [microstrain * x for x in strains]
+
+
 def _create_d_reference_array(values: Union[float, np.ndarray],
                               errors: Union[float, np.ndarray], size: int) -> unumpy.uarray:
     '''Convert the d-reference values to a :py:obj:`unumpy.uarray`
@@ -79,10 +98,13 @@ class PeakCollectionLite:
     def __init__(self, peak_tag: str,
                  strain: np.ndarray,
                  strain_error: np.ndarray,
+                 strain_units: str = 'strain',
                  d_reference: Union[float, np.ndarray] = np.nan,
                  d_reference_error: Union[float, np.ndarray] = 0.) -> None:
         self._tag: str = peak_tag
-        self._strain = unumpy.uarray(strain, strain_error)
+
+        # We need to store strains in strain units, NOT in microstrains
+        self._strain = unumpy.uarray(strain, strain_error) / get_strain_conversion_factor(strain_units)
 
         # must happen after the sub_run array is set
         self._d_reference = unumpy.uarray(np.nan, np.nan)  # set this correctly in next call

--- a/tests/integration/pyrs/dataobjects/test_fields.py
+++ b/tests/integration/pyrs/dataobjects/test_fields.py
@@ -4,7 +4,6 @@ import pytest
 
 from pyrs.dataobjects.constants import DEFAULT_POINT_RESOLUTION
 from pyrs.dataobjects.fields import fuse_scalar_field_samples, ScalarFieldSample, StrainField, StressField
-from pyrs.peaks.peak_collection import to_microstrain
 
 to_megapascal = StressField.to_megapascal
 

--- a/tests/integration/pyrs/dataobjects/test_fields.py
+++ b/tests/integration/pyrs/dataobjects/test_fields.py
@@ -4,6 +4,9 @@ import pytest
 
 from pyrs.dataobjects.constants import DEFAULT_POINT_RESOLUTION
 from pyrs.dataobjects.fields import fuse_scalar_field_samples, ScalarFieldSample, StrainField, StressField
+from pyrs.peaks.peak_collection import to_microstrain
+
+to_megapascal = StressField.to_megapascal
 
 
 @pytest.fixture(scope='module')
@@ -289,18 +292,18 @@ def test_create_stress_1(data_create_stress_1):
     trace = stress.strain11.values + stress.strain22.values + stress.strain33.values
     assert stress['11'].point_list == stress['22'].point_list
     assert stress['22'].point_list == stress['33'].point_list
-    assert np.allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
-    assert np.allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
-    assert np.allclose(stress['33'].values, stress.strain33.values + trace, equal_nan=True)
+    assert np.allclose(stress['11'].values, to_megapascal(stress.strain11.values + trace), equal_nan=True, atol=1)
+    assert np.allclose(stress['22'].values, to_megapascal(stress.strain22.values + trace), equal_nan=True, atol=1)
+    assert np.allclose(stress['33'].values, to_megapascal(stress.strain33.values + trace), equal_nan=True, atol=1)
     #
     # In-plane strain (strain33 is zero)
     poisson_ratio = 1. / 3.  # makes nu / (1 - 2*nu) == 1
     young_modulus = 1 + poisson_ratio  # makes E / (1 + nu) == 1
     stress = StressField(strain11, strain22, None, young_modulus, poisson_ratio, stress_type='in-plane-strain')
     trace = stress.strain11.values + stress.strain22.values
-    assert np.allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
-    assert np.allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
-    assert np.allclose(stress['33'].values, trace, equal_nan=True)
+    assert np.allclose(stress['11'].values, to_megapascal(stress.strain11.values + trace), equal_nan=True, atol=1)
+    assert np.allclose(stress['22'].values, to_megapascal(stress.strain22.values + trace), equal_nan=True, atol=1)
+    assert np.allclose(stress['33'].values, to_megapascal(trace), equal_nan=True, atol=1)
     assert np.all(stress.strain33.values == 0.0)
     #
     # In-plane stress (stress33 is zero)
@@ -308,10 +311,11 @@ def test_create_stress_1(data_create_stress_1):
     young_modulus = 1 + poisson_ratio
     stress = StressField(strain11, strain22, None, young_modulus, poisson_ratio, stress_type='in-plane-stress')
     trace = stress.strain11.values + stress.strain22.values
-    assert np.allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
-    assert np.allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
+    assert np.allclose(stress['11'].values, to_megapascal(stress.strain11.values + trace), equal_nan=True, atol=1)
+    assert np.allclose(stress['22'].values, to_megapascal(stress.strain22.values + trace), equal_nan=True, atol=1)
     assert np.all(stress['33'].values == 0.0)
-    assert np.allclose(stress.strain33.values, -(stress.strain11.values + stress.strain22.values), equal_nan=True)
+    assert np.allclose(stress.strain33.values,
+                       -(stress.strain11.values + stress.strain22.values), equal_nan=True, atol=1)
 
 
 if __name__ == '__main__':

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,7 +1,9 @@
 import numpy as np
 from numpy.testing import assert_allclose
+from pyrs.dataobjects.fields import StrainField, StrainFieldSingle, StressField
+from pyrs.peaks.peak_collection import to_microstrain
 
-from pyrs.dataobjects.fields import StrainField, StrainFieldSingle
+to_megapascal = StressField.to_megapascal
 
 
 def test_strain_single_builder(strain_single_builder):
@@ -39,8 +41,8 @@ def test_strain_single_builder(strain_single_builder):
     assert_allclose(strain.point_list.vx, np.array(scan['vx']))
     assert_allclose(strain.get_d_reference().values, np.repeat(scan['d_reference'], len(scan['subruns'])))
     assert_allclose(strain.get_dspacing_center().values, np.array(scan['d_spacing']))
-    strain_expected_values = (scan['d_spacing'] - scan['d_reference']) / scan['d_reference']
-    assert_allclose(strain.field.values, strain_expected_values, rtol=1e-07, atol=1.e-07)
+    strain_expected_values = to_microstrain((scan['d_spacing'] - scan['d_reference']) / scan['d_reference'])
+    assert_allclose(strain.field.values, strain_expected_values, atol=1)
     for name in ['Intensity', 'FWHM', 'Mixing', 'A0', 'A1']:
         assert_allclose(strain.get_effective_peak_parameter(name).values, np.array(scan['native'][name]))
 
@@ -80,59 +82,62 @@ def test_strain_builder(strain_builder):
     assert_allclose(strain.point_list.vx, np.array(scan['vx']))
     assert_allclose(strain.get_d_reference().values, np.repeat(scan['d_reference'], len(scan['subruns'])))
     assert_allclose(strain.get_dspacing_center().values, np.array(scan['d_spacing']))
-    strain_expected_values = (scan['d_spacing'] - scan['d_reference']) / scan['d_reference']
-    assert_allclose(strain.field.values, strain_expected_values, rtol=1e-07, atol=1.e-07)
+    strain_expected_values = to_microstrain((scan['d_spacing'] - scan['d_reference']) / scan['d_reference'])
+    assert_allclose(strain.field.values, strain_expected_values, atol=1)
     for name in ['Intensity', 'FWHM', 'Mixing', 'A0', 'A1']:
         assert_allclose(strain.get_effective_peak_parameter(name).values, np.array(scan['native'][name]))
 
 
 def test_strain_single_object_0(strain_single_object_0):
     assert isinstance(strain_single_object_0, StrainFieldSingle)
-    expected = [0.00, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07]
-    assert_allclose(strain_single_object_0.values, expected, rtol=1.e-07, atol=1.e-07)
+    expected = to_microstrain([0.00, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07])
+    assert_allclose(strain_single_object_0.values, expected, atol=1)
 
 
 def test_strain_object_0(strain_object_0):
     assert isinstance(strain_object_0, StrainField)
-    expected = [0.00, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07]
-    assert_allclose(strain_object_0.values, expected, rtol=1.e-07, atol=1.e-07)
+    expected = to_microstrain([0.00, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07])
+    assert_allclose(strain_object_0.values, expected, atol=1)
 
 
 def test_strain_object_1(strain_object_1):
     assert isinstance(strain_object_1, StrainField)
-    assert_allclose(strain_object_1.values, np.arange(0.01, 0.085, 0.01), rtol=1.e-07, atol=1.e-07)
+    expected = to_microstrain(np.arange(0.01, 0.085, 0.01))
+    assert_allclose(strain_object_1.values, expected, atol=1)
 
 
 def test_strain_object_2(strain_object_2):
     assert isinstance(strain_object_2, StrainField)
-    assert_allclose(strain_object_2.values, np.arange(0.01, 0.085, 0.01), rtol=1.e-07, atol=1.e-07)
+    expected = to_microstrain(np.arange(0.01, 0.085, 0.01))
+    assert_allclose(strain_object_2.values, expected, atol=1)
 
 
 def test_strain_stress_object_0(strain_stress_object_0):
     strains = strain_stress_object_0['strains']
-    assert_allclose(strains['11'].values, np.arange(0.0, 0.045, 0.01), rtol=1.e-07, atol=1.e-07)
-    assert_allclose(strains['22'].values, np.arange(0.10, 0.145, 0.01), rtol=1.e-07, atol=1.e-07)
-    assert_allclose(strains['33'].values, np.arange(0.20, 0.245, 0.01), rtol=1.e-07, atol=1.e-07)
+    assert_allclose(strains['11'].values, to_microstrain(np.arange(0.0, 0.045, 0.01)), atol=1)
+    assert_allclose(strains['22'].values, to_microstrain(np.arange(0.10, 0.145, 0.01)), atol=1)
+    assert_allclose(strains['33'].values, to_microstrain(np.arange(0.20, 0.245, 0.01)), atol=1)
 
     # Check stress values.  Young's modulus and Poisson ratio values yield simple formulae
     stress = strain_stress_object_0['stresses']['diagonal']
     trace = stress.strain11.values + stress.strain22.values + stress.strain33.values
-    assert_allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
-    assert_allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
-    assert_allclose(stress['33'].values, stress.strain33.values + trace, equal_nan=True)
+    assert_allclose(stress['11'].values, to_megapascal(stress.strain11.values + trace), equal_nan=True, atol=1)
+    assert_allclose(stress['22'].values, to_megapascal(stress.strain22.values + trace), equal_nan=True, atol=1)
+    assert_allclose(stress['33'].values, to_megapascal(stress.strain33.values + trace), equal_nan=True, atol=1)
 
     stress = strain_stress_object_0['stresses']['in-plane-strain']
     assert_allclose(stress.strain33.values, np.zeros(5))
     trace = stress.strain11.values + stress.strain22.values + stress.strain33.values
-    assert_allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
-    assert_allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
-    assert_allclose(stress['33'].values, stress.strain33.values + trace, equal_nan=True)
+    assert_allclose(stress['11'].values, to_megapascal(stress.strain11.values + trace), equal_nan=True, atol=1)
+    assert_allclose(stress['22'].values, to_megapascal(stress.strain22.values + trace), equal_nan=True, atol=1)
+    assert_allclose(stress['33'].values, to_megapascal(stress.strain33.values + trace), equal_nan=True, atol=1)
 
     stress = strain_stress_object_0['stresses']['in-plane-stress']
-    assert_allclose(stress.strain33.values, -1. * (stress.strain11.values + stress.strain22.values))
+    assert_allclose(stress.strain33.values,
+                    -1. * (stress.strain11.values + stress.strain22.values), equal_nan=True, atol=1)
     trace = stress.strain11.values + stress.strain22.values
-    assert_allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
-    assert_allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
+    assert_allclose(stress['11'].values, to_megapascal(stress.strain11.values + trace), equal_nan=True, atol=1)
+    assert_allclose(stress['22'].values, to_megapascal(stress.strain22.values + trace), equal_nan=True, atol=1)
     assert_allclose(stress.stress33.values, np.zeros(5))
 
 
@@ -140,27 +145,27 @@ def test_strain_stress_object_1(strain_stress_object_1):
     strains, stresses = strain_stress_object_1['strains'], strain_stress_object_1['stresses']
 
     # check strain values
-    assert_allclose(strains['11'].values, np.arange(0.0, 0.075, 0.01), rtol=1.e-07, atol=1.e-07)
-    assert_allclose(strains['22'].values, np.arange(0.01, 0.085, 0.01), rtol=1.e-07, atol=1.e-07)
-    assert_allclose(strains['33'].values, np.arange(0.02, 0.095, 0.01), rtol=1.e-07, atol=1.e-07)
+    assert_allclose(strains['11'].values, to_microstrain(np.arange(0.0, 0.075, 0.01)), atol=1)
+    assert_allclose(strains['22'].values, to_microstrain(np.arange(0.01, 0.085, 0.01)), atol=1)
+    assert_allclose(strains['33'].values, to_microstrain(np.arange(0.02, 0.095, 0.01)), atol=1)
 
     # Check stress values.  Young's modulus and Poisson ratio values yield simple formulae
     stress = stresses['diagonal']
     trace = stress.strain11.values + stress.strain22.values + stress.strain33.values
-    assert_allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
-    assert_allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
-    assert_allclose(stress['33'].values, stress.strain33.values + trace, equal_nan=True)
+    assert_allclose(stress['11'].values, to_megapascal(stress.strain11.values + trace), equal_nan=True, atol=1)
+    assert_allclose(stress['22'].values, to_megapascal(stress.strain22.values + trace), equal_nan=True, atol=1)
+    assert_allclose(stress['33'].values, to_megapascal(stress.strain33.values + trace), equal_nan=True, atol=1)
 
     stress = stresses['in-plane-strain']
     assert_allclose(stress.strain33.values, np.zeros(9))
     trace = stress.strain11.values + stress.strain22.values + stress.strain33.values
-    assert_allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
-    assert_allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
-    assert_allclose(stress['33'].values, stress.strain33.values + trace, equal_nan=True)
+    assert_allclose(stress['11'].values, to_megapascal(stress.strain11.values + trace), equal_nan=True, atol=1)
+    assert_allclose(stress['22'].values, to_megapascal(stress.strain22.values + trace), equal_nan=True, atol=1)
+    assert_allclose(stress['33'].values, to_megapascal(stress.strain33.values + trace), equal_nan=True, atol=1)
 
     stress = stresses['in-plane-stress']
     assert_allclose(stress.strain33.values, -1. * (stress.strain11.values + stress.strain22.values))
     trace = stress.strain11.values + stress.strain22.values
-    assert_allclose(stress['11'].values, stress.strain11.values + trace, equal_nan=True)
-    assert_allclose(stress['22'].values, stress.strain22.values + trace, equal_nan=True)
+    assert_allclose(stress['11'].values, to_megapascal(stress.strain11.values + trace), equal_nan=True, atol=1)
+    assert_allclose(stress['22'].values, to_megapascal(stress.strain22.values + trace), equal_nan=True, atol=1)
     assert_allclose(stress.stress33.values, np.zeros(9))


### PR DESCRIPTION
Work done:
- [x] `peak_collection.to_microstrain()` utility function
- [x] `StressField.to_megapascal()` utility function
- [x] fix test in unit.test_fields, integration.test_fields, units.test_stress_facade, test_conftest

Refs #727 