### PR TITLE
refactor AnglerCamera naming convention to DENEX

### DIFF
--- a/pyrs/calibration/peakfit_calibration.py
+++ b/pyrs/calibration/peakfit_calibration.py
@@ -11,7 +11,7 @@ from pyrs.core import MonoSetting  # type: ignore
 from pyrs.core.reduce_hb2b_pyrs import PyHB2BReduction
 from pyrs.utilities.calibration_file_io import write_calibration_to_json
 from pyrs.core.reduction_manager import HB2BReductionManager
-from pyrs.core.instrument_geometry import AnglerCameraDetectorGeometry
+from pyrs.core.instrument_geometry import DENEXDetectorGeometry
 
 # Import instrument constants
 from pyrs.core.nexus_conversion import NUM_PIXEL_1D, PIXEL_SIZE, ARM_LENGTH
@@ -142,7 +142,7 @@ class PeakFitCalibration:
 
         Parameters
         ----------
-        hb2b_inst : AnglerCameraDetectorGeometry
+        hb2b_inst : DENEXDetectorGeometry
             Overide default instrument configuration
         powder_engine : HiDraWorksapce
             HiDraWorksapce with powder raw counts and log data
@@ -159,9 +159,9 @@ class PeakFitCalibration:
 
         # define instrument setup
         if hb2b_inst is None:
-            self._instrument = AnglerCameraDetectorGeometry(NUM_PIXEL_1D, NUM_PIXEL_1D,
-                                                            PIXEL_SIZE, PIXEL_SIZE,
-                                                            ARM_LENGTH, False)
+            self._instrument = DENEXDetectorGeometry(NUM_PIXEL_1D, NUM_PIXEL_1D,
+                                                     PIXEL_SIZE, PIXEL_SIZE,
+                                                     ARM_LENGTH, False)
         else:
             self._instrument = hb2b_inst
 
@@ -946,14 +946,14 @@ class PeakFitCalibration:
         -------
         None
         """
-        from pyrs.core.instrument_geometry import AnglerCameraDetectorShift
-        # Form AnglerCameraDetectorShift objects
-        cal_shift = AnglerCameraDetectorShift(self._calib[0], self._calib[1], self._calib[2], self._calib[3],
-                                              self._calib[4], self._calib[5], self._calib[7])
+        from pyrs.core.instrument_geometry import DENEXDetectorShift
+        # Form DENEXDetectorShift objects
+        cal_shift = DENEXDetectorShift(self._calib[0], self._calib[1], self._calib[2], self._calib[3],
+                                       self._calib[4], self._calib[5], self._calib[7])
 
-        cal_shift_error = AnglerCameraDetectorShift(self._caliberr[0], self._caliberr[1], self._caliberr[2],
-                                                    self._caliberr[3], self._caliberr[4], self._caliberr[5],
-                                                    self._caliberr[7])
+        cal_shift_error = DENEXDetectorShift(self._caliberr[0], self._caliberr[1], self._caliberr[2],
+                                             self._caliberr[3], self._caliberr[4], self._caliberr[5],
+                                             self._caliberr[7])
 
         wl = self._calib[6]
         wl_error = self._caliberr[6]

--- a/pyrs/core/instrument_geometry.py
+++ b/pyrs/core/instrument_geometry.py
@@ -22,11 +22,10 @@ class HidraSetup:
 
         Parameters
         ----------
-        l1
         detector_setup
         """
         # check inputs
-        checkdatatypes.check_type('Detector geometry setup', detector_setup, AnglerCameraDetectorGeometry)
+        checkdatatypes.check_type('Detector geometry setup', detector_setup, DENEXDetectorGeometry)
 
         # set for original instrument setup defined by engineering
         self._geometry_setup = detector_setup
@@ -85,7 +84,7 @@ class HidraSetup:
         return 'HB2B'
 
 
-class AnglerCameraDetectorGeometry:
+class DENEXDetectorGeometry:
     """
     A class to handle and save instrument geometry setup
     """
@@ -94,7 +93,7 @@ class AnglerCameraDetectorGeometry:
                  pixel_size_x: float, pixel_size_y: float,
                  arm_length: float, calibrated: bool) -> None:
         """
-        Initialization of instrument geometry setup for 1 angler camera
+        Initialization of instrument geometry setup for 1 denex detector
         :param num_rows: number of rows of pixels in detector (number of pixels per column)
         :param num_columns: number of columns of pixels in detector (number of pixels per row)
         :param pixel_size_x: pixel size at X direction (along a row)
@@ -112,7 +111,7 @@ class AnglerCameraDetectorGeometry:
         checkdatatypes.check_bool_variable('Flag indicating instrument setup been calibrated', calibrated)
 
     def apply_shift(self, geometry_shift):
-        checkdatatypes.check_type('Detector geometry shift', geometry_shift, AnglerCameraDetectorShift)
+        checkdatatypes.check_type('Detector geometry shift', geometry_shift, DENEXDetectorShift)
 
         self._arm_length += geometry_shift.center_shift_z
 
@@ -137,7 +136,7 @@ class AnglerCameraDetectorGeometry:
         return self._pixel_size_x, self._pixel_size_y
 
 
-class AnglerCameraDetectorShift:
+class DENEXDetectorShift:
     """
     A class to handle and save instrument geometry calibration information
     """
@@ -298,7 +297,7 @@ class AnglerCameraDetectorShift:
         jfile.close()
 
     def from_json(self, file_name):
-        """ Convert from a Json string (dicionary) and set to parameters
+        """ Convert from a Json string (dictionary) and set to parameters
         :param file_name: json file name
         :return:
         """
@@ -318,5 +317,5 @@ class AnglerCameraDetectorShift:
 
 if __name__ == '__main__':
     # Test main
-    shift = AnglerCameraDetectorShift(0., 0., 0., 0., 0., 0.)
+    shift = DENEXDetectorShift(0., 0., 0., 0., 0., 0.)
     shift.to_json('geometry_shift_template.json')

--- a/pyrs/core/nexus_conversion.py
+++ b/pyrs/core/nexus_conversion.py
@@ -9,7 +9,7 @@ from mantid.simpleapi import mtd, DeleteWorkspace, LoadEventNexus, LoadMask, Rem
 import numpy as np
 import os
 from pyrs.core import workspaces
-from pyrs.core.instrument_geometry import AnglerCameraDetectorGeometry, HidraSetup
+from pyrs.core.instrument_geometry import DENEXDetectorGeometry, HidraSetup
 from pyrs.core import MonoSetting  # type: ignore
 from pyrs.dataobjects import HidraConstants  # type: ignore
 from pyrs.projectfile import HidraProjectFile, HidraProjectFileMode  # type: ignore
@@ -275,8 +275,9 @@ class NeXusConvertingApp:
         # Set a default instrument with this workspace
         # set up instrument
         # initialize instrument with hard coded values
-        instrument = AnglerCameraDetectorGeometry(NUM_PIXEL_1D, NUM_PIXEL_1D, PIXEL_SIZE, PIXEL_SIZE,
-                                                  ARM_LENGTH, False)
+        instrument = DENEXDetectorGeometry(NUM_PIXEL_1D, NUM_PIXEL_1D, PIXEL_SIZE, PIXEL_SIZE,
+                                           ARM_LENGTH, False)
+
         self._hidra_workspace.set_instrument_geometry(instrument)
 
         # project file

--- a/pyrs/core/pyrscore.py
+++ b/pyrs/core/pyrscore.py
@@ -265,7 +265,7 @@ class PyRsCore:
         :param num_bins:
         :param pyrs_engine:
         :param mask_file_name:
-        :param geometry_calibration: True/file name/AnglerCameraDetectorShift/None), False, None/(False, )
+        :param geometry_calibration: True/file name/DENEXDetectorShift/None), False, None/(False, )
         :param sub_run_list: list of sub run numbers or None (for all)
         :return:
         """
@@ -283,11 +283,11 @@ class PyRsCore:
             apply_calibration = False
         elif isinstance(geometry_calibration, str):
             # From a Json file
-            calib_shift = instrument_geometry.AnglerCameraDetectorShift(0, 0, 0, 0, 0, 0)
+            calib_shift = instrument_geometry.DENEXDetectorShift(0, 0, 0, 0, 0, 0)
             calib_shift.from_json(geometry_calibration)
             apply_calibration = calib_shift
-        elif isinstance(geometry_calibration, instrument_geometry.AnglerCameraDetectorShift):
-            # Already a AnglerCameraDetectorShift instance
+        elif isinstance(geometry_calibration, instrument_geometry.DENEXDetectorShift):
+            # Already a DENEXDetectorShift instance
             apply_calibration = geometry_calibration
         elif geometry_calibration is True:
             # Use what is loaded from file or set to workspace before

--- a/pyrs/core/reduction_manager.py
+++ b/pyrs/core/reduction_manager.py
@@ -259,8 +259,8 @@ class HB2BReductionManager:
         Parameters
         ----------
         session_name
-        apply_calibrated_geometry : ~AnglerCameraDetectorShift or bool
-            3 options (1) user-provided AnglerCameraDetectorShift
+        apply_calibrated_geometry : ~DENEXDetectorShift or bool
+            3 options (1) user-provided DENEXDetectorShift
                                           (2) True (use the one in workspace) (3) False (no calibration)
         num_bins : int
             number of bins
@@ -315,7 +315,7 @@ class HB2BReductionManager:
             mask_vec *= default_mask
 
         # Apply (or not) instrument geometry calibration shift
-        if isinstance(apply_calibrated_geometry, instrument_geometry.AnglerCameraDetectorShift):
+        if isinstance(apply_calibrated_geometry, instrument_geometry.DENEXDetectorShift):
             det_pos_shift = apply_calibrated_geometry
         elif apply_calibrated_geometry:
             det_pos_shift = workspace.get_detector_shift()
@@ -382,7 +382,7 @@ class HB2BReductionManager:
             workspace with detector counts and position
         sub_run : integer
             sub run number in workspace to reduce
-        geometry_calibration : instrument_geometry.AnglerCameraDetectorShift
+        geometry_calibration : instrument_geometry.DENEXDetectorShift
             instrument geometry to calculate diffraction pattern
 
         Returns
@@ -449,7 +449,7 @@ class HB2BReductionManager:
             workspace with detector counts and position
         sub_run : integer
             sub run number in workspace to reduce
-        geometry_calibration : instrument_geometry.AnglerCameraDetectorShift
+        geometry_calibration : instrument_geometry.DENEXDetectorShift
             instrument geometry to calculate diffraction pattern
         mask_vec_tuple : tuple (str, numpy.ndarray)
             mask ID and 1D array for masking (1 to keep, 0 to mask out)
@@ -567,7 +567,7 @@ class HB2BReductionManager:
             workspace with detector counts and position
         sub_run : integer
             sub run number in workspace to reduce
-        geometry_calibration : instrument_geometry.AnglerCameraDetectorShift
+        geometry_calibration : instrument_geometry.DENEXDetectorShift
             instrument geometry to calculate diffraction pattern
         mask_vec_tuple : tuple (str, numpy.ndarray)
             mask ID and 1D array for masking (1 to keep, 0 to mask out)
@@ -662,7 +662,7 @@ class HB2BReductionManager:
             2theta increment in the reduced diffraction data
         mask_array : numpy.ndarray or None
             mask: 1 to keep, 0 to mask (exclude)
-        vanadium_counts : numpy.ndarray or None
+        vanadium_array : numpy.ndarray or None
             detector pixels' vanadium for efficiency and normalization.
             If vanadium duration is recorded, the vanadium counts are normalized by its duration in seconds
 
@@ -705,7 +705,7 @@ class HB2BReductionManager:
         min_2theta : float or None
             minimum 2theta or None
         num_bins : int
-            nubmer of bins
+            number of bins
         max_2theta : float  or None
              maximum 2theta and must be integer
         pixel_2theta_array : numpy.ndarray

--- a/pyrs/peaks/mantid_fit_peak.py
+++ b/pyrs/peaks/mantid_fit_peak.py
@@ -12,10 +12,12 @@ DEBUG = False   # Flag for debugging mode
 
 class MantidPeakFitEngine(PeakFitEngine):
     '''Peak fitting engine by calling mantid'''
+
     def __init__(self, hidraworkspace, peak_function_name, background_function_name, out_of_plane_angle, wavelength):
         super(MantidPeakFitEngine, self).__init__(hidraworkspace, peak_function_name,
                                                   background_function_name, wavelength=wavelength,
                                                   out_of_plane_angle=out_of_plane_angle)
+
         # configure logging for this class
         self._log = Logger(__name__)
 

--- a/pyrs/projectfile/file_object.py
+++ b/pyrs/projectfile/file_object.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pyrs.utilities import checkdatatypes
 from pyrs.utilities.convertdatatypes import to_float, to_int
 from pyrs.utilities.file_util import to_filepath
-from pyrs.core.instrument_geometry import AnglerCameraDetectorGeometry, HidraSetup
+from pyrs.core.instrument_geometry import DENEXDetectorGeometry, HidraSetup
 from pyrs.peaks import PeakCollection  # type: ignore
 from pyrs.dataobjects import HidraConstants, SampleLogs  # type: ignore
 from pyrs.projectfile import HidraProjectFileMode  # type: ignore
@@ -470,12 +470,12 @@ class HidraProjectFile:
         arm_length = detector_group['L2'].value
 
         # Initialize
-        instrument_setup = AnglerCameraDetectorGeometry(num_rows=num_rows,
-                                                        num_columns=num_cols,
-                                                        pixel_size_x=pixel_size_x,
-                                                        pixel_size_y=pixel_size_y,
-                                                        arm_length=arm_length,
-                                                        calibrated=False)
+        instrument_setup = DENEXDetectorGeometry(num_rows=num_rows,
+                                                 num_columns=num_cols,
+                                                 pixel_size_x=pixel_size_x,
+                                                 pixel_size_y=pixel_size_y,
+                                                 arm_length=arm_length,
+                                                 calibrated=False)
 
         return instrument_setup
 

--- a/pyrs/utilities/calibration_file_io.py
+++ b/pyrs/utilities/calibration_file_io.py
@@ -1,6 +1,6 @@
 # Class providing a series of static methods to work with files
 from pyrs.utilities import checkdatatypes
-from pyrs.core.instrument_geometry import AnglerCameraDetectorShift, AnglerCameraDetectorGeometry
+from pyrs.core.instrument_geometry import DENEXDetectorShift, DENEXDetectorGeometry
 import json
 
 
@@ -33,7 +33,7 @@ def read_calibration_json_file(calibration_file_name):
     Returns
     -------
     ~tuple
-        (AnglerCameraDetectorShift, AnglerCameraDetectorShift, float, float, int)
+        (DENEXDetectorShift, DENEXDetectorShift, float, float, int)
         detector position shifts as the calibration result,detector position shifts error from fitting
         status
 
@@ -48,27 +48,27 @@ def read_calibration_json_file(calibration_file_name):
     if calib_dict is None:
         raise RuntimeError('Failed to load JSON calibration file {}'.format(calibration_file_name))
 
-    # Convert dictionary to AnglerCameraDetectorShift
+    # Convert dictionary to DENEXDetectorShift
     try:
-        shift = AnglerCameraDetectorShift(shift_x=calib_dict['Shift_x'],
-                                          shift_y=calib_dict['Shift_y'],
-                                          shift_z=calib_dict['Shift_z'],
-                                          rotation_x=calib_dict['Rot_x'],
-                                          rotation_y=calib_dict['Rot_y'],
-                                          rotation_z=calib_dict['Rot_z'],
-                                          two_theta_0=calib_dict['two_theta_0'])
+        shift = DENEXDetectorShift(shift_x=calib_dict['Shift_x'],
+                                   shift_y=calib_dict['Shift_y'],
+                                   shift_z=calib_dict['Shift_z'],
+                                   rotation_x=calib_dict['Rot_x'],
+                                   rotation_y=calib_dict['Rot_y'],
+                                   rotation_z=calib_dict['Rot_z'],
+                                   two_theta_0=calib_dict['two_theta_0'])
     except KeyError as key_error:
         raise RuntimeError('Missing key parameter from JSON file {}: {}'.format(calibration_file_name, key_error))
 
     # shift error
     try:
-        shift_error = AnglerCameraDetectorShift(shift_x=calib_dict['error_Shift_x'],
-                                                shift_y=calib_dict['error_Shift_y'],
-                                                shift_z=calib_dict['error_Shift_z'],
-                                                rotation_x=calib_dict['error_Rot_x'],
-                                                rotation_y=calib_dict['error_Rot_y'],
-                                                rotation_z=calib_dict['error_Rot_z'],
-                                                two_theta_0=calib_dict['error_two_theta_0'])
+        shift_error = DENEXDetectorShift(shift_x=calib_dict['error_Shift_x'],
+                                         shift_y=calib_dict['error_Shift_y'],
+                                         shift_z=calib_dict['error_Shift_z'],
+                                         rotation_x=calib_dict['error_Rot_x'],
+                                         rotation_y=calib_dict['error_Rot_y'],
+                                         rotation_z=calib_dict['error_Rot_z'],
+                                         two_theta_0=calib_dict['error_two_theta_0'])
 
     except KeyError as key_error:
         raise RuntimeError('Missing key parameter from JSON file {}: {}'.format(calibration_file_name, key_error))
@@ -103,7 +103,7 @@ def import_calibration_ascii_file(geometry_file_name):
     checkdatatypes.check_file_name(geometry_file_name, True, False, False, 'Geometry configuration file in ASCII')
 
     # init output
-    calibration_setup = AnglerCameraDetectorShift(0, 0, 0, 0, 0, 0)
+    calibration_setup = DENEXDetectorShift(0, 0, 0, 0, 0, 0)
 
     calibration_file = open(geometry_file_name, 'r')
     geom_lines = calibration_file.readlines()
@@ -157,7 +157,7 @@ def import_instrument_setup(instrument_ascii_file):
 
     Returns
     -------
-    AnglerCameraDetectorGeometry
+    DENEXDetectorGeometry
         Instrument geometry setup for HB2B
 
     """
@@ -197,12 +197,12 @@ def import_instrument_setup(instrument_ascii_file):
             raise RuntimeError('Argument {} is not recognized'.format(arg_name))
     # END-FOR
 
-    instrument = AnglerCameraDetectorGeometry(num_rows=detector_rows,
-                                              num_columns=detector_columns,
-                                              pixel_size_x=pixel_size_x,
-                                              pixel_size_y=pixel_size_y,
-                                              arm_length=arm_length,
-                                              calibrated=False)
+    instrument = DENEXDetectorGeometry(num_rows=detector_rows,
+                                       num_columns=detector_columns,
+                                       pixel_size_x=pixel_size_x,
+                                       pixel_size_y=pixel_size_y,
+                                       arm_length=arm_length,
+                                       calibrated=False)
 
     return instrument
 
@@ -220,8 +220,8 @@ def write_calibration_to_json(shifts, shifts_error, wave_length, wave_lenngth_er
     """
     # Check inputs
     checkdatatypes.check_file_name(file_name, False, True, False, 'Output JSON calibration file')
-    assert isinstance(shifts, AnglerCameraDetectorShift)
-    assert isinstance(shifts_error, AnglerCameraDetectorShift)
+    assert isinstance(shifts, DENEXDetectorShift)
+    assert isinstance(shifts_error, DENEXDetectorShift)
 
     # Create calibration dictionary
     calibration_dict = shifts.convert_to_dict()

--- a/tests/integration/test_powder_pattern.py
+++ b/tests/integration/test_powder_pattern.py
@@ -6,7 +6,7 @@ import numpy as np
 import h5py
 from pyrs.core.workspaces import HidraWorkspace
 from pyrs.core.reduce_hb2b_pyrs import ResidualStressInstrument
-from pyrs.core.instrument_geometry import AnglerCameraDetectorGeometry
+from pyrs.core.instrument_geometry import DENEXDetectorGeometry
 from pyrs.core.reduction_manager import HB2BReductionManager
 import pytest
 
@@ -87,7 +87,7 @@ def test_2theta_calculation():
     # Create geometry setup
     pixel_size = 0.3 / 1024.0
     arm_length = 0.985
-    test_setup = AnglerCameraDetectorGeometry(1024, 1024, pixel_size, pixel_size, arm_length, False)
+    test_setup = DENEXDetectorGeometry(1024, 1024, pixel_size, pixel_size, arm_length, False)
     # Create instrument
     instrument = ResidualStressInstrument(test_setup)
 


### PR DESCRIPTION
Refactor AnglerCamera to DENEX. plus a refactor of reduce_hb2b_pyrs to a single "import numpy as np" and not "import numpy and import numpy as np"