### PR TITLE
Sort points in scalar field according to (x, y, z) values

### DIFF
--- a/pyrs.sh
+++ b/pyrs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # check that a valid mantidpython was found
-MANTIDPYTHON=mantidpythonnightly
+MANTIDPYTHON=mantidpython51
 if [ ! $(command -v $MANTIDPYTHON) ]; then
     echo "Failed to find mantidpython \"$MANTIDPYTHON\""
     exit -1

--- a/pyrs/dataobjects/sample_logs.py
+++ b/pyrs/dataobjects/sample_logs.py
@@ -752,6 +752,20 @@ class PointList:
         return np.allclose(self.vx, other.vx, atol=self.ATOL) and np.allclose(self.vy, other.vy, atol=self.ATOL) \
             and np.allclose(self.vz, other.vz, atol=self.ATOL)
 
+    def sort(self) -> None:
+        r"""Reorder the points in the list by increasing vz, then by increasing vy, and finally by
+         increasing vx"""
+        coordinates = sorted([xyz.tolist() for xyz in self.coordinates])
+        self._vx, self._vy, self._vz = np.array(coordinates).transpose()
+
+    def argsort(self) -> np.ndarray:
+        r"""Return the permutation that reorder the points in the list by increasing vz, then by increasing vy,
+         and finally by increasing vx"""
+        enumerated_coordinates = [[i, x.tolist()] for i, x in enumerate(self.coordinates)]
+        enumerated_coordinates_sorted = sorted(enumerated_coordinates, key=lambda a: a[1])
+        permutation = [i for i, _ in enumerated_coordinates_sorted]
+        return np.array(permutation)
+
     def is_contained_in(self, other: 'PointList', resolution: float = DEFAULT_POINT_RESOLUTION) -> bool:
         r"""
         For every point in the list, check that a point in the other list exist within

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -286,6 +286,15 @@ class TestScalarFieldSample:
         for attribute in ('values', 'errors', 'x', 'y', 'z'):
             assert getattr(field, attribute) == pytest.approx([0.1, 0.2, 0.5, 0.6])
 
+    def test_sort(self):
+        field = ScalarFieldSample(*TestScalarFieldSample.sample3)
+        field.sort()
+        assert field.x == pytest.approx([0, 0, 0, 0, 0.5, 0.5, 0.5, 0.5])
+        assert field.y == pytest.approx([1, 1, 1.5, 1.5, 1, 1, 1.5, 1.5])
+        assert field.z == pytest.approx([2, 2.5, 2, 2.5, 2, 2.5, 2, 2.5])
+        assert field.values == pytest.approx([1, 5, 3, 7, 2, 6, 4, 8])
+        assert field.errors == pytest.approx([0.1, 0.5, 0.3, 0.7, 0.2, 0.6, 0.4, 0.8])
+
     def test_interpolated_sample_regular(self, field_cube_regular):
         r"""
         Test with an input regular grid. No interpolation should be necessary because

--- a/tests/unit/pyrs/dataobjects/test_fields.py
+++ b/tests/unit/pyrs/dataobjects/test_fields.py
@@ -498,8 +498,9 @@ class TestScalarFieldSample:
             assert dimension.getMaximum() == pytest.approx(max_value + 0.25)
             assert dimension.getNBins() == 2
 
-        np.testing.assert_equal(histo.getSignalArray().ravel(), self.sample3.values, err_msg='Signal')
-        np.testing.assert_equal(histo.getErrorSquaredArray().ravel(), np.square(self.sample3.errors), err_msg='Errors')
+        field.sort()  # converting to MDHistoWorkspace does sort the input scalar field
+        np.testing.assert_equal(histo.getSignalArray().ravel(), field.values, err_msg='Signal')
+        np.testing.assert_equal(histo.getErrorSquaredArray().ravel(), np.square(field.errors), err_msg='Errors')
 
         # clean up
         histo.delete()

--- a/tests/unit/pyrs/dataobjects/test_sample_logs.py
+++ b/tests/unit/pyrs/dataobjects/test_sample_logs.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 import pytest
 from pyrs.dataobjects.constants import HidraConstants, DEFAULT_POINT_RESOLUTION
 from pyrs.dataobjects.sample_logs import DirectionExtents, PointList, aggregate_point_lists, SampleLogs
@@ -241,6 +242,18 @@ class TestPointList:
     def test_coordinates(self, sample_logs_mock):
         point_list = PointList(sample_logs_mock['logs'])
         np.testing.assert_allclose(point_list.coordinates, np.array(sample_logs_mock['xyz']).transpose())
+
+    def test_sort(self):
+        xyz = [[0, 0, 0, 0], [1, 2, 1, 2], [3, 3, 4, 4]]
+        point_list = PointList(xyz)
+        point_list.sort()
+        assert_array_almost_equal(point_list.vy, [1, 1, 2, 2], decimal=1)
+        assert_array_almost_equal(point_list.vz, [3, 4, 3, 4], decimal=1)
+
+    def test_argsort(self):
+        xyz = [[0, 0, 0, 0], [1, 2, 1, 2], [3, 3, 4, 4]]
+        point_list = PointList(xyz)
+        assert_array_equal(point_list.argsort(), [0, 2, 1, 3])
 
     def test_coordinates_along_direction(self):
         xyz = [[0, 1], [2, 3], [4, 5]]


### PR DESCRIPTION
**Work Done:**
- [x] Sort `PointList` accoding to increasing `Vz`, then increasing `Vy`, then increasing `Vx`
- [x] Sort `ScalarFieldSample` according to previous `PointList` sorting
- [x] Sort `ScalarFieldSample` according to previous sorting before converting to `MDHistoWorkspace`

For details, see [PyRS #2](https://code.ornl.gov/sns-hfir-scse/diffraction/engineering-diffraction/PyRS/-/issues/2#characterization-of-run-2250)
