### PR TITLE
Switch to boa for building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,8 @@ jobs:
       - name: Install Boa for conda build
         run: |
           conda activate PyRS
-          conda install -c conda-forge mamba
           # boa uses mamba to resolve dependencies
-          mamba install -y -c conda-forge anaconda-client boa
+          conda install -y -c conda-forge anaconda-client boa
 
       - name: Build conda package
         # Build in all cases, for testing purposes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           conda activate PyRS
           conda install -c conda-forge mamba
           # boa uses mamba to resolve dependencies
-          mamba install -y anaconda-client boa
+          mamba install -y -c conda-forge anaconda-client boa
 
       - name: Build conda package
         # Build in all cases, for testing purposes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,12 +89,6 @@ jobs:
           python setup.py bdist_wheel
           check-wheel-contents dist/pyrs-*.whl
 
-      - name: Install Boa for conda build
-        run: |
-          conda activate PyRS
-          # boa uses mamba to resolve dependencies
-          conda install -y -c conda-forge anaconda-client boa
-
       - name: Build conda package
         # Build in all cases, for testing purposes
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,6 @@ jobs:
         run: |
           # --quiet should turn off progress bars to make logs more readable
           conda env create --file environment.yml --quiet
-          # boa uses mamba to resolve dependencies
-          conda install -y -n PyRS anaconda-client boa
 
       - name: Lint
         run: |
@@ -90,6 +88,13 @@ jobs:
           conda activate PyRS
           python setup.py bdist_wheel
           check-wheel-contents dist/pyrs-*.whl
+
+      - name: Install Boa for conda build
+        run: |
+          conda activate PyRS
+          conda install -c conda-forge mamba
+          # boa uses mamba to resolve dependencies
+          mamba install -y anaconda-client boa
 
       - name: Build conda package
         # Build in all cases, for testing purposes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         run: |
           # --quiet should turn off progress bars to make logs more readable
           conda env create --file environment.yml --quiet
+          # boa uses mamba to resolve dependencies
+          conda install -y -n PyRS anaconda-client boa
 
       - name: Lint
         run: |
@@ -93,8 +95,6 @@ jobs:
         # Build in all cases, for testing purposes
         run: |
           conda activate PyRS
-          # boa uses mamba to resolve dependencies
-          conda install -y anaconda-client boa
           cd conda.recipe
           conda mambabuild --output-folder . . -c conda-forge -c mantid
           conda verify noarch/pyrs-*py*.tar.bz2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,10 @@ jobs:
         # Build in all cases, for testing purposes
         run: |
           conda activate PyRS
+          # boa uses mamba to resolve dependencies
+          conda install -y anaconda-client boa
           cd conda.recipe
-          conda build --output-folder . . -c conda-forge -c mantid 
+          conda mambabuild --output-folder . . -c conda-forge -c mantid
           conda verify noarch/pyrs-*py*.tar.bz2
 
       - name: Publish to Anaconda

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,8 @@ channels:
 - mantid
 dependencies:
 - python=3.8
+- anaconda-client
+- boa
 - mantidworkbench
 - qtpy
 - pyqt =5.12


### PR DESCRIPTION
[boa](https://github.com/mamba-org/boa) uses the dependency solver from mamba which is the longest step of creating this conda package.