### PR TITLE
Re-add: CRON job lost during pixi migration.

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -7,7 +7,10 @@ on:
     tags: ['v*']
   pull_request:
     # Run on pull requests targeting any base branch
-
+  schedule:
+    # daily cron job at UTC+6 == EST+1
+    - cron: '0 6 * * *'
+    
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -2,10 +2,14 @@ name: unit-test
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches: [next, qa, main]
     tags: ['v*']
+  pull_request:
+    # Run on pull requests targeting any base branch
+  schedule:
+    # daily cron job at UTC+6 == EST+1
+    - cron: '0 6 * * *'
 
 jobs:
   linux:


### PR DESCRIPTION
# Short description of the changes:
Re-add daily CI CRON job.

# Long description of the changes:
After the Pixi migration, the daily CRON job had been omitted from the CI actions.  These changes add those lines back.

# References 
EWM: [ticket #12857](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=12857)
